### PR TITLE
Auto-hide the filter bar and rework visibility settings

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -177,7 +177,7 @@
     <addaction name="menu_View_2"/>
     <addaction name="actionPreserveView"/>
     <addaction name="separator"/>
-    <addaction name="actionFilter"/>
+    <addaction name="actionClearFilter"/>
     <addaction name="actionMenu_bar"/>
    </widget>
    <widget class="QMenu" name="menu_Editw">
@@ -717,12 +717,12 @@
     <string>F3</string>
    </property>
   </action>
-  <action name="actionFilter">
+  <action name="actionClearFilter">
    <property name="checkable">
-    <bool>true</bool>
+    <bool>false</bool>
    </property>
    <property name="text">
-    <string>&amp;Filter</string>
+    <string>&amp;Clear filter</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+B</string>

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -102,7 +102,7 @@ protected Q_SLOTS:
   void on_actionDescending_triggered(bool checked);
   void on_actionFolderFirst_triggered(bool checked);
   void on_actionCaseSensitive_triggered(bool checked);
-  void on_actionFilter_triggered(bool checked);
+  void on_actionClearFilter_triggered();
 
   void on_actionApplications_triggered();
   void on_actionComputer_triggered();
@@ -164,6 +164,7 @@ protected:
   void closeTab(int index);
   virtual void resizeEvent(QResizeEvent *event);
   virtual void closeEvent(QCloseEvent *event);
+  virtual bool eventFilter(QObject *object, QEvent* event);
 
 private:
   static void onBookmarksChanged(FmBookmarks* bookmarks, MainWindow* pThis);

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -481,45 +481,58 @@ above the folder-view and not above the left pane.</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="0" colspan="2">
+            <item row="3" column="0" colspan="2">
              <widget class="QCheckBox" name="showTabClose">
               <property name="text">
                <string>Show 'Close' buttons on tabs	</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="0" colspan="2">
+            <item row="4" column="0" colspan="2">
              <widget class="QCheckBox" name="rememberWindowSize">
               <property name="text">
                <string>Remember the size of the last closed window</string>
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
+            <item row="5" column="0">
              <widget class="QLabel" name="label_12">
               <property name="text">
                <string>Default width of new windows:</string>
               </property>
              </widget>
             </item>
-            <item row="4" column="1">
+            <item row="5" column="1">
              <widget class="QSpinBox" name="fixedWindowWidth">
               <property name="maximum">
                <number>32768</number>
               </property>
              </widget>
             </item>
-            <item row="5" column="0">
+            <item row="6" column="0">
              <widget class="QLabel" name="label_13">
               <property name="text">
                <string>Default height of new windows:</string>
               </property>
              </widget>
             </item>
-            <item row="5" column="1">
+            <item row="6" column="1">
              <widget class="QSpinBox" name="fixedWindowHeight">
               <property name="maximum">
                <number>32768</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0" colspan="2">
+             <widget class="QCheckBox" name="alwaysShowFilter">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Always show filter bar</string>
               </property>
              </widget>
             </item>

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -170,6 +170,7 @@ void PreferencesDialog::initDisplayPage(Settings& settings) {
 
 void PreferencesDialog::initUiPage(Settings& settings) {
   ui.alwaysShowTabs->setChecked(settings.alwaysShowTabs());
+  ui.alwaysShowFilter->setChecked(settings.alwaysShowFilter());
   ui.fullWidthTabbar->setChecked(settings.fullWidthTabBar());
   ui.showTabClose->setChecked(settings.showTabClose());
   ui.rememberWindowSize->setChecked(settings.rememberWindowSize());
@@ -293,6 +294,7 @@ void PreferencesDialog::applyDisplayPage(Settings& settings) {
 
 void PreferencesDialog::applyUiPage(Settings& settings) {
   settings.setAlwaysShowTabs(ui.alwaysShowTabs->isChecked());
+  settings.setAlwaysShowFilter(ui.alwaysShowFilter->isChecked());
   settings.setFullWidthTabBar(ui.fullWidthTabbar->isChecked());
   settings.setShowTabClose(ui.showTabClose->isChecked());
   settings.setRememberWindowSize(ui.rememberWindowSize->isChecked());

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -90,7 +90,7 @@ Settings::Settings():
   sortColumn_(Fm::FolderModel::ColumnFileName),
   sortFolderFirst_(true),
   sortCaseSensitive_(false),
-  showFilter_(false),
+  alwaysShowFilter_(false),
   // settings for use with libfm
   singleClick_(false),
   autoSelectionDelay_(600),
@@ -240,7 +240,7 @@ bool Settings::loadFile(QString filePath) {
   sortColumn_ = sortColumnFromString(settings.value("SortColumn").toString());
   sortFolderFirst_ = settings.value("SortFolderFirst", true).toBool();
   sortCaseSensitive_ = settings.value("SortCaseSensitive", false).toBool();
-  showFilter_ = settings.value("ShowFilter", false).toBool();
+  alwaysShowFilter_ = settings.value("AlwaysShowFilter", false).toBool();
 
   setBackupAsHidden(settings.value("BackupAsHidden", false).toBool());
   showFullNames_ = settings.value("ShowFullNames", false).toBool();
@@ -350,7 +350,7 @@ bool Settings::saveFile(QString filePath) {
   settings.setValue("SortColumn", sortColumnToString(sortColumn_));
   settings.setValue("SortFolderFirst", sortFolderFirst_);
   settings.setValue("SortCaseSensitive", sortCaseSensitive_);
-  settings.setValue("ShowFilter", showFilter_);
+  settings.setValue("AlwaysShowFilter", alwaysShowFilter_);
 
   settings.setValue("BackupAsHidden", backupAsHidden_);
   settings.setValue("ShowFullNames", showFullNames_);

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -526,12 +526,12 @@ public:
     sortFolderFirst_ = folderFirst;
   }
 
-  bool showFilter() const {
-    return showFilter_;
+  bool alwaysShowFilter() const {
+    return alwaysShowFilter_;
   }
 
-  void setShowFilter(bool value) {
-    showFilter_ = value;
+  void setAlwaysShowFilter(bool value) {
+    alwaysShowFilter_ = value;
   }
 
   // settings for use with libfm
@@ -789,7 +789,7 @@ private:
   Fm::FolderModel::ColumnId sortColumn_;
   bool sortFolderFirst_;
   bool sortCaseSensitive_;
-  bool showFilter_;
+  bool alwaysShowFilter_;
 
   // settings for use with libfm
   bool singleClick_;


### PR DESCRIPTION
This pull request is a proposed rework of how the filter bar visibility is handled, this was already partially discussed in https://github.com/lxde/pcmanfm-qt/issues/311, but I still think the current way of handling it is not quite right.

So right now we basically have two actions for the filter bar, one that toggles visibility (and changes the settings), and one that focuses the filter bar. Obviously the filter bar can't be focused if it's hidden so the focus shortcut actually also triggers the visibility shortcut (and thus changes the settings), which means that to hide the filter bar again you _have_ to use the visibility shortcut.

I think this is bad because it ties the preference of having the filter bar visible or not by default to the actual use of the filter bar, for example if I close a pcmanfm-qt with an active filter an open it again the filter bar will be visible, this is wrong.

So this pull request:
- Adds a preference whether to filter bar should always be visible or not
- Automatically hides the filter bar if no filter is active (unless the preference is set to always visible)
- Replaces the filter bar visibility shortcut with a clear filter shortcut

Which means that we have one shortcut to start filtering, one shortcut to stop filtering, and a preference for the filter bar visibility, instead of one shortcut to toggle the visibility and one shortcut to start filtering _and_ activate the visibility.
