### PR TITLE
Optionally select newly created files

### DIFF
--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -114,6 +114,9 @@ protected Q_SLOTS:
     void onModelSortFilterChanged();
     void onIndexesMoved(const QModelIndexList& indexes);
     void onDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight);
+    void onFolderStartLoading();
+    void onFolderFinishLoading();
+    void onFilesAdded(const Fm::FileInfoList files);
 
     void relayoutItems();
     void onStickToCurrentPos(bool toggled);
@@ -160,6 +163,7 @@ private:
     std::unordered_map<std::string, QPoint> customItemPos_;
     QHash<QModelIndex, QString> displayNames_; // only for desktop entries and shortcuts
     QTimer* relayoutTimer_;
+    QTimer* selectionTimer_;
 };
 
 }

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -194,6 +194,13 @@
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QCheckBox" name="selectNewFiles">
+              <property name="text">
+               <string>Select newly created files</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -220,6 +220,7 @@ void PreferencesDialog::initBehaviorPage(Settings& settings) {
     ui.noUsbTrash->setChecked(settings.noUsbTrash());
     ui.confirmTrash->setChecked(settings.confirmTrash());
     ui.quickExec->setChecked(settings.quickExec());
+    ui.selectNewFiles->setChecked(settings.selectNewFiles());
 }
 
 void PreferencesDialog::initThumbnailPage(Settings& settings) {
@@ -328,6 +329,7 @@ void PreferencesDialog::applyBehaviorPage(Settings& settings) {
     settings.setNoUsbTrash(ui.noUsbTrash->isChecked());
     settings.setConfirmTrash(ui.confirmTrash->isChecked());
     settings.setQuickExec(ui.quickExec->isChecked());
+    settings.setSelectNewFiles(ui.selectNewFiles->isChecked());
 }
 
 void PreferencesDialog::applyThumbnailPage(Settings& settings) {

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -105,6 +105,7 @@ Settings::Settings():
     noUsbTrash_(false),
     confirmTrash_(false),
     quickExec_(false),
+    selectNewFiles_(false),
     showThumbnails_(true),
     archiver_(),
     siUnit_(false),
@@ -208,6 +209,7 @@ bool Settings::loadFile(QString filePath) {
     setNoUsbTrash(settings.value("NoUsbTrash", false).toBool());
     confirmTrash_ = settings.value("ConfirmTrash", false).toBool();
     setQuickExec(settings.value("QuickExec", false).toBool());
+    selectNewFiles_ = settings.value("SelectNewFiles", false).toBool();
     // bool thumbnailLocal_;
     // bool thumbnailMax;
     settings.endGroup();
@@ -342,6 +344,7 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue("NoUsbTrash", noUsbTrash_);
     settings.setValue("ConfirmTrash", confirmTrash_);
     settings.setValue("QuickExec", quickExec_);
+    settings.setValue("SelectNewFiles", selectNewFiles_);
     // bool thumbnailLocal_;
     // bool thumbnailMax;
     settings.endGroup();

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -670,6 +670,14 @@ public:
         fm_config->quick_exec = quickExec_;
     }
 
+    bool selectNewFiles() const {
+        return selectNewFiles_;
+    }
+
+    void setSelectNewFiles(bool value) {
+        selectNewFiles_ = value;
+    }
+
     // bool thumbnailLocal_;
     // bool thumbnailMax;
 
@@ -930,6 +938,7 @@ private:
     bool noUsbTrash_; // do not trash files on usb removable devices
     bool confirmTrash_; // Confirm before moving files into "trash can"
     bool quickExec_; // Don't ask options on launch executable file
+    bool selectNewFiles_;
 
     bool showThumbnails_;
 

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -210,6 +210,7 @@ protected Q_SLOTS:
     void onSelChanged();
     void onUiUpdated();
     void onFileSizeChanged(const QModelIndex& index);
+    void onFilesAdded(const Fm::FileInfoList files);
 
 private:
     void freeFolder();
@@ -241,6 +242,7 @@ private:
     Fm::FilePath lastFolderPath_; // last browsed folder
     bool overrideCursor_;
     FolderSettings folderSettings_;
+    QTimer* selectionTimer_;
 };
 
 }


### PR DESCRIPTION
Closes https://github.com/lxde/pcmanfm-qt/issues/638.

This depends on and follows https://github.com/lxde/libfm-qt/pull/170.

With a new option (unchecked by default) at the end of Preferences → Behavior → File Operations, newly created files are selected and scrolled to appropriately when they are new enough -- whether they are created by pcmanfm-qt or in any other way.

The above-mentioned option is for Desktop too and can be enabled/disabled on-the-fly.

Also, the case of changing Desktop folder is covered.