### PR TITLE
Fully drop dependency on libfm C library.

### DIFF
--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -689,7 +689,6 @@ void Settings::setTerminal(QString terminalCommand) {
     // override the settings in libfm FmConfig.
     g_free(fm_config->terminal);
     fm_config->terminal = g_strdup(terminal_.toLocal8Bit().constData());
-    g_signal_emit_by_name(fm_config, "changed::terminal");
 }
 
 

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -285,13 +285,9 @@ void TabPage::onFolderFsInfo() {
     guint64 free, total;
     QString& msg = statusText_[StatusTextFSInfo];
     if(folder_->getFilesystemInfo(&total, &free)) {
-        char total_str[64];
-        char free_str[64];
-        fm_file_size_to_str(free_str, sizeof(free_str), free, fm_config->si_unit);
-        fm_file_size_to_str(total_str, sizeof(total_str), total, fm_config->si_unit);
         msg = tr("Free space: %1 (Total: %2)")
-              .arg(QString::fromUtf8(free_str),
-              QString::fromUtf8(total_str));
+              .arg(formatFileSize(free, fm_config->si_unit))
+              .arg(formatFileSize(total, fm_config->si_unit));
     }
     else {
         msg.clear();


### PR DESCRIPTION
This adopts the changes in https://github.com/lxqt/libfm-qt/pull/196
With this, pcmanfm-qt and libfm-qt no longer depend on libfm C library.
