### PR TITLE
Fix the functionality of "Connect to remote server"

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -475,7 +475,7 @@ void Application::onConnectToServerAccepted() {
     ConnectServerDialog* dlg = static_cast<ConnectServerDialog*>(sender());
     QString uri = dlg->uriText();
     Fm::FilePathList paths;
-    paths.push_back(Fm::FilePath::fromDisplayName(uri.toUtf8().constData()));
+    paths.push_back(Fm::FilePath::fromUri(uri.toUtf8().constData()));
     MainWindow* window = MainWindow::lastActive();
     Launcher(window).launchPaths(nullptr, paths);
 }


### PR DESCRIPTION
By correcting handling of URIs

Depends on https://github.com/lxqt/libfm-qt/pull/210

Testing: install `gvfs` package and connect to an sftp server via Go -> Connect to remote

PS. This bug is originally reported at the Arhc Linux bug tracker: https://bugs.archlinux.org/task/58940
