### PR TITLE
Removes local compile definition

### DIFF
--- a/pcmanfm/CMakeLists.txt
+++ b/pcmanfm/CMakeLists.txt
@@ -68,7 +68,6 @@ target_compile_definitions(pcmanfm-qt
         PCMANFM_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/pcmanfm-qt"
         PCMANFM_QT_VERSION="${PCMANFM_QT_VERSION}"
         LIBFM_DATA_DIR="${PKG_FM_PREFIX}/share/libfm"
-        QT_NO_FOREACH
 )
 
 target_include_directories(pcmanfm-qt


### PR DESCRIPTION
QT_NO_FOREACH is already part of LXQtCompilerSettings CMake module.