### PR TITLE
Fix closing tab on ejecting/unmounting

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -703,7 +703,7 @@ void MainWindow::onTabBarTabMoved(int from, int to) {
 
 void MainWindow::onFolderUnmounted() {
     TabPage* tabPage = static_cast<TabPage*>(sender());
-    QList<MountOperation*> ops = ui.sidePane->findChildren<MountOperation*>();
+    const QList<MountOperation*> ops = ui.sidePane->findChildren<MountOperation*>();
     if(ops.isEmpty()) { // unmounting is done somewhere else
         Settings& settings = static_cast<Application*>(qApp)->settings();
         if(settings.closeOnUnmount()) {

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -163,6 +163,8 @@ protected Q_SLOTS:
 
     void onBackForwardContextMenu(QPoint pos);
 
+    void onFolderUnmounted();
+
     void tabContextMenu(const QPoint& pos);
     void closeLeftTabs();
     void closeRightTabs();

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -337,21 +337,12 @@ void TabPage::onFolderRemoved() {
 void TabPage::onFolderUnmount() {
     // the folder we're showing is unmounted, destroy the widget
     qDebug("folder unmount");
-    // NOTE: call deleteLater() directly from this GObject signal handler
-    // does not work but I don't know why.
-    // Maybe it's the problem of glib mainloop integration?
-    // Call it when idle works, though.
-    Settings& settings = static_cast<Application*>(qApp)->settings();
-    // NOTE: call deleteLater() directly from this GObject signal handler
-    // does not work but I don't know why.
-    // Maybe it's the problem of glib mainloop integration?
-    // Call it when idle works, though.
-    if(settings.closeOnUnmount()) {
-        QTimer::singleShot(0, this, SLOT(deleteLater()));
-    }
-    else {
-        chdir(Fm::FilePath::homeDir());
-    }
+    // NOTE: We cannot delete the page or change its directory here
+    // because unmounting might be done from places view, in which case,
+    // the mount operation is a child of the places view and should be
+    // finished before doing anything else.
+    freeFolder();
+    Q_EMIT folderUnmounted();
 }
 
 void TabPage::onFolderContentChanged() {

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -203,6 +203,7 @@ Q_SIGNALS:
     void sortFilterChanged();
     void forwardRequested();
     void backwardRequested();
+    void folderUnmounted();
 
 protected Q_SLOTS:
     void onSelChanged();


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/695

When unmounting/ejecting is done from the places view, we should wait for the process to be finished (and auto-destroyed) and only then, remove the tab page; otherwise, the process might be finished with error because its object is a child of the places view.

For the sake of certainty, the same thing is done in the case of changing directory to user's home (I've seen random crashes with various backtraces otherwise).

Please also note that `QObject::destroyed` is used instead of `MountOperation::finished` intentionally, for cases of multiple operations (which may be practically impossible).