### PR TITLE
Restart warning for Preferences

### DIFF
--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -890,6 +890,22 @@ above the folder-view and not above the left pane.</string>
     </layout>
    </item>
    <item>
+    <widget class="QLabel" name="warningLabel">
+     <property name="styleSheet">
+      <string notr="true">background-color:#7d0000; color:white; font-weight:bold; border-radius:3px; margin:2px; padding:5px;</string>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="text">
+      <string>Application restart is needed for changes to take effect.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -36,6 +36,8 @@ PreferencesDialog::PreferencesDialog(QString activePage, QWidget* parent):
     QDialog(parent) {
     ui.setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
+    warningCounter_ = 0;
+    ui.warningLabel->hide();
 
     // resize the list widget according to the width of its content.
     ui.listWidget->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
@@ -167,6 +169,14 @@ void PreferencesDialog::initDisplayPage(Settings& settings) {
 
     ui.showFullNames->setChecked(settings.showFullNames());
     ui.shadowHidden->setChecked(settings.shadowHidden());
+
+    // app restart warning
+    connect(ui.showFullNames, &QAbstractButton::toggled, [this, &settings] (bool checked) {
+       restartWarning(settings.showFullNames() != checked);
+    });
+    connect(ui.shadowHidden, &QAbstractButton::toggled, [this, &settings] (bool checked) {
+       restartWarning(settings.shadowHidden() != checked);
+    });
 }
 
 void PreferencesDialog::initUiPage(Settings& settings) {
@@ -217,6 +227,11 @@ void PreferencesDialog::initBehaviorPage(Settings& settings) {
     ui.confirmTrash->setChecked(settings.confirmTrash());
     ui.quickExec->setChecked(settings.quickExec());
     ui.selectNewFiles->setChecked(settings.selectNewFiles());
+
+    // app restart warning
+    connect(ui.quickExec, &QAbstractButton::toggled, [this, &settings] (bool checked) {
+       restartWarning(settings.quickExec() != checked);
+    });
 }
 
 void PreferencesDialog::initThumbnailPage(Settings& settings) {
@@ -391,6 +406,16 @@ void PreferencesDialog::lockMargins(bool lock) {
     else {
         disconnect(ui.hMargin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), ui.vMargin, &QSpinBox::setValue);
     }
+}
+
+void PreferencesDialog::restartWarning(bool warn) {
+    if(warn) {
+        ++warningCounter_;
+    }
+    else {
+        --warningCounter_;
+    }
+    ui.warningLabel->setVisible(warningCounter_ > 0);
 }
 
 } // namespace PCManFM

--- a/pcmanfm/preferencesdialog.h
+++ b/pcmanfm/preferencesdialog.h
@@ -65,8 +65,11 @@ private:
     void initFromSettings();
     void applySettings();
 
+    void restartWarning(bool warn);
+
 private:
     Ui::PreferencesDialog ui;
+    int warningCounter_;
 };
 
 }


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/750

The restart warning is a clearly visible message that's shown only when an app restart is really needed. These settings are included:

 * Lanuch executable files without prompt
 * Always show full names
 * Show icons of hidden files shadowed

If some settings are missed, they could be easily included too.