### PR TITLE
Transient filter-bar by default

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -84,19 +84,6 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QLineEdit" name="filterBar">
-          <property name="toolTip">
-           <string>Focus with Ctrl+I</string>
-          </property>
-          <property name="placeholderText">
-           <string>Filter by string...</string>
-          </property>
-          <property name="clearButtonEnabled">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
        </layout>
       </widget>
      </widget>
@@ -187,6 +174,13 @@
      <addaction name="actionLocationBar"/>
      <addaction name="actionPathButtons"/>
     </widget>
+    <widget class="QMenu" name="menuFiltering">
+     <property name="title">
+      <string>&amp;Filtering</string>
+     </property>
+     <addaction name="actionShowFilter"/>
+     <addaction name="actionUnfilter"/>
+    </widget>
     <addaction name="actionReload"/>
     <addaction name="separator"/>
     <addaction name="actionShowHidden"/>
@@ -196,6 +190,8 @@
     <addaction name="separator"/>
     <addaction name="menuToolbars"/>
     <addaction name="menuPathBarStyle"/>
+    <addaction name="separator"/>
+    <addaction name="menuFiltering"/>
    </widget>
    <widget class="QMenu" name="menu_Edit">
     <property name="title">
@@ -752,10 +748,18 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>&amp;Filter</string>
+    <string>Permanent &amp;filter bar</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+B</string>
+   </property>
+  </action>
+  <action name="actionUnfilter">
+   <property name="text">
+    <string>&amp;Clear All Filters</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+K</string>
    </property>
   </action>
   <action name="actionCloseLeft">
@@ -845,6 +849,17 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+F2</string>
+   </property>
+  </action>
+  <action name="actionShowFilter">
+   <property name="text">
+    <string>&amp;Show/Focus Filter Bar</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Filter Bar</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+I</string>
    </property>
   </action>
  </widget>

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -114,6 +114,8 @@ protected Q_SLOTS:
     void on_actionFolderFirst_triggered(bool checked);
     void on_actionCaseSensitive_triggered(bool checked);
     void on_actionFilter_triggered(bool checked);
+    void on_actionUnfilter_triggered();
+    void on_actionShowFilter_triggered();
 
     void on_actionLocationBar_triggered(bool checked);
     void on_actionPathButtons_triggered(bool checked);
@@ -137,9 +139,6 @@ protected Q_SLOTS:
     void onTabBarCloseRequested(int index);
     void onTabBarCurrentChanged(int index);
     void onTabBarTabMoved(int from, int to);
-
-    void focusFilterBar();
-    void onFilterStringChanged(QString str);
 
     void onShortcutPrevTab();
     void onShortcutNextTab();


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/744

Filter-bars are either "transient" (the default) or "permanent" (`Ctl+B` toggles that):

 * When a filter-bar is transient, it'll pop up automatically as soon as the user starts typing inside the view and it'll disappear again if its text is cleared in any way (by typing `Ctrl+K`, for example). Typing inside the view is like typing inside the filter-bar but the view remains focused. That makes working with filters much easier.

 * When a filter-bar is permanent, the filtering behavior is as before: the text should be typed inside the focused filter-bar. (It is kept only for backward compatibility; I really think it isn't needed.)

 * Each tab page has its own filter-bar, visually identical to others, so that the undo/redo history isn't cleared with tab switching. With transient filter-bars, each tab shows its filter-bar only when there is filtering in that tab.

 * A "Filtering" sub-menu is also added to the View menu with two items: one for focusing/showing the filter-bar (`Ctrl+I`, which wasn't shown in the GUI before) and another for clearing all filters in all tabs (`Ctrl+Shift+K`). When an empty transient filter-bar is shown by `Ctrl+I`, it'll disappear on losing focus unless some text is typed in it.

 * There are more properties that can be seen in practice.