### PR TITLE
Focus the view on changing its mode

### DIFF
--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -719,6 +719,7 @@ void TabPage::setViewMode(Fm::FolderView::ViewMode mode) {
         }
     }
     folderView_->setViewMode(mode);
+    folderView_->childView()->setFocus();
     if(!settings.showFilter()) {
         // FolderView::setViewMode() may delete the view to switch between list and tree.
         // So, the event filter should be re-installed.


### PR DESCRIPTION
When the mode was changed from/to the detalied list, the view lost focus because it was deleted and recreated. Here, the focus is returned to it, for the sake of consistency.