### PR TITLE
Added split view

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -32,19 +32,6 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="PCManFM::TabBar" name="tabBar" native="true">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="acceptDrops">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item>
      <widget class="QSplitter" name="splitter">
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
@@ -57,34 +44,10 @@
         </sizepolicy>
        </property>
       </widget>
-      <widget class="QFrame" name="frame">
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <property name="spacing">
-         <number>2</number>
-        </property>
-        <property name="leftMargin">
-         <number>1</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QStackedWidget" name="stackedWidget">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <widget class="QSplitter" name="viewSplitter">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
       </widget>
      </widget>
     </item>
@@ -184,6 +147,7 @@
     <addaction name="actionReload"/>
     <addaction name="separator"/>
     <addaction name="actionShowHidden"/>
+    <addaction name="actionSplitView"/>
     <addaction name="menuSorting"/>
     <addaction name="menu_View_2"/>
     <addaction name="actionPreserveView"/>
@@ -862,14 +826,22 @@
     <string>Ctrl+I</string>
    </property>
   </action>
+  <action name="actionSplitView">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>S&amp;plit View</string>
+   </property>
+   <property name="toolTip">
+    <string>Split View</string>
+   </property>
+   <property name="shortcut">
+    <string>F6</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>PCManFM::TabBar</class>
-   <extends>QWidget</extends>
-   <header>tabbar.h</header>
-   <container>1</container>
-  </customwidget>
   <customwidget>
    <class>PCManFM::StatusBar</class>
    <extends>QStatusBar</extends>

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -375,14 +375,15 @@ bool MainWindow::eventFilter(QObject* watched, QEvent* event) {
                         palette.setColor(QPalette::Active, QPalette::ButtonText, txtCol);
                         palette.setColor(QPalette::Inactive, QPalette::ButtonText, txtCol);
 
+                        // There are various ways of getting a distinct color near the base color
+                        // but this one gives the best results with almost all palettes:
                         QColor baseCol = palette.color(QPalette::Base);
-                        if(qGray(baseCol.rgb()) <= 100) { // dark theme (supposedly)
-                            baseCol = baseCol.lighter(110);
-                        }
-                        else { // light theme (supposedly)
-                            baseCol = baseCol.darker(110);
-                        }
+                        baseCol.setRgbF(0.9 * baseCol.redF()   + 0.1 * txtCol.redF(),
+                                        0.9 * baseCol.greenF() + 0.1 * txtCol.greenF(),
+                                        0.9 * baseCol.blueF()  + 0.1 * txtCol.blueF(),
+                                        baseCol.alphaF());
                         palette.setColor(QPalette::Base, baseCol);
+
                         viewFrame->setPalette(palette);
                     }
                 }

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -53,6 +53,68 @@ using namespace Fm;
 
 namespace PCManFM {
 
+ViewFrame::ViewFrame(QWidget* parent):
+    QFrame(parent),
+    topBar_(nullptr) {
+    QVBoxLayout* vBox = new QVBoxLayout;
+    vBox->setContentsMargins(0, 0, 0, 0);
+
+    tabBar_ = new TabBar;
+    stackedWidget_ = new QStackedWidget;
+    vBox->addWidget(tabBar_);
+    vBox->addWidget(stackedWidget_, 1);
+    setLayout(vBox);
+
+    // tabbed browsing interface
+    tabBar_->setDocumentMode(true);
+    tabBar_->setElideMode(Qt::ElideRight);
+    tabBar_->setExpanding(false);
+    tabBar_->setMovable(true); // reorder the tabs by dragging
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    // switch to the tab under the cursor during dnd.
+    tabBar_->setChangeCurrentOnDrag(true);
+    tabBar_->setAcceptDrops(true);
+#endif
+    tabBar_->setContextMenuPolicy(Qt::CustomContextMenu);
+}
+
+void ViewFrame::createTopBar(bool usePathButtons) {
+    if(QVBoxLayout* vBox = qobject_cast<QVBoxLayout*>(layout())) {
+        if(usePathButtons) {
+            if (qobject_cast<Fm::PathEdit*>(topBar_)) {
+                delete topBar_;
+                topBar_ = nullptr;
+            }
+            if(topBar_ == nullptr) {
+                topBar_ = new Fm::PathBar();
+                vBox->insertWidget(0, topBar_);
+            }
+        }
+        else {
+            if(qobject_cast<Fm::PathBar*>(topBar_)) {
+                delete topBar_;
+                topBar_ = nullptr;
+            }
+            if(topBar_ == nullptr) {
+                topBar_ = new Fm::PathEdit();
+                vBox->insertWidget(0, topBar_);
+            }
+        }
+    }
+}
+
+void ViewFrame::removeTopBar() {
+    if(topBar_ != nullptr){
+        if(QVBoxLayout* vBox = qobject_cast<QVBoxLayout*>(layout())) {
+            vBox->removeWidget(topBar_);
+            delete topBar_;
+            topBar_ = nullptr;
+        }
+    }
+}
+
+//======================================================================
+
 // static
 MainWindow* MainWindow::lastActive_ = nullptr;
 
@@ -63,12 +125,16 @@ MainWindow::MainWindow(Fm::FilePath path):
     bookmarks_{Fm::Bookmarks::globalInstance()},
     fileLauncher_(this),
     rightClickIndex_(-1),
-    updatingViewMenu_(false) {
+    updatingViewMenu_(false),
+    menuSpacer_(nullptr),
+    activeViewFrame_(nullptr) {
 
     Settings& settings = static_cast<Application*>(qApp)->settings();
     setAttribute(Qt::WA_DeleteOnClose);
     // setup user interface
     ui.setupUi(this);
+
+    splitView_ = settings.splitView();
 
     // hide menu items that are not usable
     //if(!uriExists("computer:///"))
@@ -91,34 +157,9 @@ MainWindow::MainWindow(Fm::FilePath path):
     backButton->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(backButton, &QToolButton::customContextMenuRequested, this, &MainWindow::onBackForwardContextMenu);
 
-    // tabbed browsing interface
-    ui.tabBar->setDocumentMode(true);
-    ui.tabBar->setTabsClosable(settings.showTabClose());
-    ui.tabBar->setElideMode(Qt::ElideRight);
-    ui.tabBar->setExpanding(false);
-    ui.tabBar->setMovable(true); // reorder the tabs by dragging
-    if(!settings.fullWidthTabBar()) {
-        ui.verticalLayout->removeWidget(ui.tabBar);
-        ui.verticalLayout_2->insertWidget(0, ui.tabBar);
-    }
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
-    // switch to the tab under the cursor during dnd.
-    ui.tabBar->setChangeCurrentOnDrag(true);
-    ui.tabBar->setAcceptDrops(true);
-#endif
-
-    ui.tabBar->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui.actionCloseRight, &QAction::triggered, this, &MainWindow::closeRightTabs);
     connect(ui.actionCloseLeft, &QAction::triggered, this, &MainWindow::closeLeftTabs);
     connect(ui.actionCloseOther, &QAction::triggered, this, &MainWindow::closeOtherTabs);
-
-    connect(ui.tabBar, &QTabBar::currentChanged, this, &MainWindow::onTabBarCurrentChanged);
-    connect(ui.tabBar, &QTabBar::tabCloseRequested, this, &MainWindow::onTabBarCloseRequested);
-    connect(ui.tabBar, &QTabBar::tabMoved, this, &MainWindow::onTabBarTabMoved);
-    connect(ui.tabBar, &QTabBar::customContextMenuRequested, this, &MainWindow::tabContextMenu);
-    connect(ui.tabBar, &TabBar::tabDetached, this, &MainWindow::detachTab);
-    connect(ui.stackedWidget, &QStackedWidget::widgetRemoved, this, &MainWindow::onStackedWidgetWidgetRemoved);
 
     ui.actionFilter->setChecked(settings.showFilter());
 
@@ -136,15 +177,6 @@ MainWindow::MainWindow(Fm::FilePath path):
 
     // detect change of splitter position
     connect(ui.splitter, &QSplitter::splitterMoved, this, &MainWindow::onSplitterMoved);
-
-    // path bar
-    createPathBar(settings.pathBarButtons());
-    if(settings.pathBarButtons()) {
-        ui.actionPathButtons->setChecked(true);
-    }
-    else {
-        ui.actionLocationBar->setChecked(true);
-    }
 
     // add filesystem info to status bar
     fsInfoLabel_ = new QLabel(ui.statusbar);
@@ -215,7 +247,7 @@ MainWindow::MainWindow(Fm::FilePath path):
     menuBtn->setPopupMode(QToolButton::InstantPopup);
 
     menuSep_ = ui.toolBar->insertSeparator(ui.actionMenu);
-    menuSep_->setVisible(!settings.showMenuBar());
+    menuSep_->setVisible(!settings.showMenuBar() && !splitView_);
     ui.actionMenu->setVisible(!settings.showMenuBar());
     ui.menubar->setVisible(settings.showMenuBar());
     ui.actionMenu_bar->setChecked(settings.showMenuBar());
@@ -273,8 +305,29 @@ MainWindow::MainWindow(Fm::FilePath path):
     shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_F), this);
     connect(shortcut, &QShortcut::activated, ui.actionFindFiles, &QAction::trigger);
 
-    if(path) {
-        addTab(path);
+    addViewFrame(path);
+    if(splitView_) {
+        // put the menu button on the right (there's no path bar/entry on the toolbar)
+        QWidget* w = new QWidget(this);
+        w->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+        menuSpacer_ = ui.toolBar->insertWidget(ui.actionMenu, w);
+
+        ui.actionSplitView->setChecked(true);
+        addViewFrame(path);
+        qApp->removeEventFilter(this); // precaution
+        qApp->installEventFilter(this);
+    }
+    else {
+        ui.actionSplitView->setChecked(false);
+        setAcceptDrops(true); // we want tab dnd in the simple mode
+    }
+    createPathBar(settings.pathBarButtons());
+
+    if(settings.pathBarButtons()) {
+        ui.actionPathButtons->setChecked(true);
+    }
+    else {
+        ui.actionLocationBar->setChecked(true);
     }
 
     // size from settings
@@ -286,46 +339,284 @@ MainWindow::MainWindow(Fm::FilePath path):
     if(QApplication::layoutDirection() == Qt::RightToLeft) {
         setRTLIcons(true);
     }
-
-    // we want tab dnd
-    setAcceptDrops(true);
 }
 
 MainWindow::~MainWindow() {
 }
 
-void MainWindow::chdir(Fm::FilePath path) {
+// Activate a view frame appropriately and give a special style to the inactive one(s).
+// NOTE: This function is called only with the split mode.
+bool MainWindow::eventFilter(QObject* watched, QEvent* event) {
+    if(qobject_cast<QWidget*>(watched)) {
+        if((event->type() == QEvent::FocusIn)
+           // the event has happened inside the splitter
+           && ui.viewSplitter->isAncestorOf(qobject_cast<QWidget*>(watched))) {
+            for(int i = 0; i < ui.viewSplitter->count(); ++i) {
+                if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(ui.viewSplitter->widget(i))) {
+                    if(viewFrame->isAncestorOf(qobject_cast<QWidget*>(watched))) {
+                        // a widget inside this view frame has gained focus; ensure the view is active
+                        if(activeViewFrame_ != viewFrame) {
+                            activeViewFrame_ = viewFrame;
+                            updateUIForCurrentPage(false); // WARNING: never refocus!
+                        }
+                        if(viewFrame->palette() != qApp->palette()) {
+                            viewFrame->setPalette(qApp->palette()); // restore the main palette
+                        }
+                    }
+                    else if (viewFrame->palette() == qApp->palette()) {
+                        // Change the text and base palettes of an inactive view frame a little.
+                        // NOTE: Style-sheets aren't used because they can interfere with QStyle.
+                        QPalette palette = viewFrame->palette();
+                        QColor txtCol = palette.color(QPalette::Text);
+                        txtCol.setAlphaF(txtCol.alphaF() * 0.7);
+                        palette.setColor(QPalette::Text, txtCol);
+                        palette.setColor(QPalette::WindowText, txtCol); // tabs
+                        // the disabled text color of path-bars shouldn't change because it may be used by arrows
+                        palette.setColor(QPalette::Active, QPalette::ButtonText, txtCol);
+                        palette.setColor(QPalette::Inactive, QPalette::ButtonText, txtCol);
+
+                        QColor baseCol = palette.color(QPalette::Base);
+                        if(qGray(baseCol.rgb()) <= 100) { // dark theme (supposedly)
+                            baseCol = baseCol.lighter(110);
+                        }
+                        else { // light theme (supposedly)
+                            baseCol = baseCol.darker(110);
+                        }
+                        palette.setColor(QPalette::Base, baseCol);
+                        viewFrame->setPalette(palette);
+                    }
+                }
+            }
+        }
+        // Use the Tab key for switching between view frames
+        else if (event->type() == QEvent::KeyPress
+                 && !qobject_cast<QTextEdit*>(watched) // not during inline renaming
+                 && ui.viewSplitter->isAncestorOf(qobject_cast<QWidget*>(watched))) {
+            if(QKeyEvent *ke = static_cast<QKeyEvent*>(event)) {
+                if(ke->key() == Qt::Key_Tab && ke->modifiers() == Qt::NoModifier) {
+                    // wrap the focus
+                    for(int i = 0; i < ui.viewSplitter->count(); ++i) {
+                        if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(ui.viewSplitter->widget(i))) {
+                            if(activeViewFrame_ == viewFrame) {
+                                activeViewFrame_ = i < ui.viewSplitter->count() - 1
+                                                    ? qobject_cast<ViewFrame*>(ui.viewSplitter->widget(i + 1))
+                                                    : qobject_cast<ViewFrame*>(ui.viewSplitter->widget(0));
+                                updateUIForCurrentPage(); // focus the view and calls this function again
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return QMainWindow::eventFilter(watched, event);
+}
+
+void MainWindow::addViewFrame(const Fm::FilePath& path) {
+    ui.actionGo->setVisible(false);
+    Settings& settings = static_cast<Application*>(qApp)->settings();
+    ViewFrame* viewFrame = new ViewFrame();
+    viewFrame->getTabBar()->setDetachable(!splitView_); // no tab DND with the split view
+    viewFrame->getTabBar()->setTabsClosable(settings.showTabClose());
+    ui.viewSplitter->addWidget(viewFrame); // the splitter takes ownership of viewFrame
+    if(ui.viewSplitter->count() == 1) {
+        activeViewFrame_ = viewFrame;
+    }
+    else { // give equal widths to all view frames
+        QTimer::singleShot(0, this, [this] {
+            QList<int> sizes;
+            for(int i = 0; i < ui.viewSplitter->count(); ++i) {
+                sizes << ui.viewSplitter->width() / ui.viewSplitter->count();
+            }
+            ui.viewSplitter->setSizes(sizes);
+        });
+    }
+
+    connect(viewFrame->getTabBar(), &QTabBar::currentChanged, this, &MainWindow::onTabBarCurrentChanged);
+    connect(viewFrame->getTabBar(), &QTabBar::tabCloseRequested, this, &MainWindow::onTabBarCloseRequested);
+    connect(viewFrame->getTabBar(), &QTabBar::tabMoved, this, &MainWindow::onTabBarTabMoved);
+    connect(viewFrame->getTabBar(), &QTabBar::customContextMenuRequested, this, &MainWindow::tabContextMenu);
+    connect(viewFrame->getTabBar(), &TabBar::tabDetached, this, &MainWindow::detachTab);
+    connect(viewFrame->getStackedWidget(), &QStackedWidget::widgetRemoved, this, &MainWindow::onStackedWidgetWidgetRemoved);
+
+    if(path) {
+        addTab(path, viewFrame);
+    }
+}
+
+void MainWindow::on_actionSplitView_triggered(bool checked) {
+    if(splitView_ == checked) {
+        return;
+    }
+    Settings& settings = static_cast<Application*>(qApp)->settings();
+    splitView_ = checked;
+    settings.setSplitView(splitView_);
+    if(splitView_) { // split the view
+        // remove the path bar/entry from the toolbar
+        ui.actionGo->setVisible(false);
+        menuSep_->setVisible(false);
+        if(pathBar_ != nullptr) {
+            delete pathBar_;
+            pathBar_ = nullptr;
+        }
+        else if(pathEntry_ != nullptr) {
+            delete pathEntry_;
+            pathEntry_ = nullptr;
+        }
+
+        // add a spacer before the menu action if not exisitng
+        if(menuSpacer_ == nullptr) {
+            QWidget* w = new QWidget(this);
+            w->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+            menuSpacer_ = ui.toolBar->insertWidget(ui.actionMenu, w);
+        }
+        menuSpacer_->setVisible(true);
+
+        // disable tab DND
+        activeViewFrame_->getTabBar()->setDetachable(false);
+        setAcceptDrops(false);
+
+        // add the current path to a new view frame
+        Fm::FilePath path;
+        TabPage* page = currentPage();
+        if(page) {
+            path = page->path();
+        }
+        addViewFrame(path);
+        qApp->removeEventFilter(this); // precaution
+        qApp->installEventFilter(this);
+        createPathBar(settings.pathBarButtons());
+
+        // reset the focus for the inactive view frame(s) to be styled by MainWindow::eventFilter()
+        if(page) {
+            page->folderView()->childView()->clearFocus();
+            page->folderView()->childView()->setFocus();
+        }
+    }
+    else { // remove splitting
+        menuSep_->setVisible(!settings.showMenuBar());
+        qApp->removeEventFilter(this);
+        for(int i = 0; i < ui.viewSplitter->count(); ++i) {
+            if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(ui.viewSplitter->widget(i))) {
+                if(viewFrame != activeViewFrame_) {
+                    viewFrame->deleteLater(); // this may be called by onStackedWidgetWidgetRemoved()
+                }
+            }
+        }
+
+        // enable tab DND
+        activeViewFrame_->getTabBar()->setDetachable(true);
+        setAcceptDrops(true);
+
+        activeViewFrame_->removeTopBar();
+        if(menuSpacer_ != nullptr) {
+            menuSpacer_->setVisible(false);
+        }
+        createPathBar(settings.pathBarButtons());
+    }
+}
+
+ViewFrame* MainWindow::viewFrameForTabPage(TabPage* page) {
+    if(page) {
+        if(QStackedWidget* sw = qobject_cast<QStackedWidget*>(page->parentWidget())) {
+            if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(sw->parentWidget())) {
+                return viewFrame;
+            }
+        }
+    }
+    return nullptr;
+}
+
+void MainWindow::chdir(Fm::FilePath path, ViewFrame* viewFrame) {
     // wait until queued events are processed
-    QTimer::singleShot(0, this, [this, path] {
-        if(TabPage* page = currentPage()) {
+    QTimer::singleShot(0, viewFrame, [this, path, viewFrame] {
+        if(TabPage* page = currentPage(viewFrame)) {
             page->chdir(path, true);
-            updateUIForCurrentPage();
+            if(viewFrame == activeViewFrame_){
+                updateUIForCurrentPage();
+            }
+            else {
+                if(Fm::PathBar* pathBar = qobject_cast<Fm::PathBar*>(viewFrame->getTopBar())) {
+                    pathBar->setPath(page->path());
+                }
+                else if(Fm::PathEdit* pathEntry = qobject_cast<Fm::PathEdit*>(viewFrame->getTopBar())) {
+                    pathEntry->setText(page->pathName());
+                }
+            }
         }
     });
 }
 
 void MainWindow::createPathBar(bool usePathButtons) {
-    QWidget* bar;
-    if(usePathButtons) {
-        bar = pathBar_ = new Fm::PathBar(this);
-        connect(pathBar_, &Fm::PathBar::chdir, this, &MainWindow::onPathBarChdir);
-        connect(pathBar_, &Fm::PathBar::middleClickChdir, this, &MainWindow::onPathBarMiddleClickChdir);
-        connect(pathBar_, &Fm::PathBar::editingFinished, this, &MainWindow::onResetFocus);
+    // NOTE: In the simple mode, path bars/entries are created before tab pages while
+    // in the split mode, they are created after tab pages and their paths/texts should be set.
+    if(splitView_) {
+        for(int i = 0; i < ui.viewSplitter->count(); ++i) {
+            if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(ui.viewSplitter->widget(i))) {
+                viewFrame->createTopBar(usePathButtons);
+                TabPage* curPage = currentPage(viewFrame);
+                if(Fm::PathBar* pathBar = qobject_cast<Fm::PathBar*>(viewFrame->getTopBar())) {
+                    connect(pathBar, &Fm::PathBar::chdir, this, &MainWindow::onPathBarChdir);
+                    connect(pathBar, &Fm::PathBar::middleClickChdir, this, &MainWindow::onPathBarMiddleClickChdir);
+                    connect(pathBar, &Fm::PathBar::editingFinished, this, &MainWindow::onResetFocus);
+                    if(curPage) {
+                        pathBar->setPath(curPage->path());
+                    }
+                }
+                else if(Fm::PathEdit* pathEntry = qobject_cast<Fm::PathEdit*>(viewFrame->getTopBar())) {
+                    connect(pathEntry, &Fm::PathEdit::returnPressed, this, &MainWindow::onPathEntryReturnPressed);
+                    if(curPage) {
+                        pathEntry->setText(curPage->pathName());
+                    }
+                }
+            }
+        }
     }
     else {
-        bar = pathEntry_ = new Fm::PathEdit(this);
-        connect(pathEntry_, &Fm::PathEdit::returnPressed, this, &MainWindow::onPathEntryReturnPressed);
+        QWidget* bar = nullptr;
+        TabPage* curPage = currentPage();
+        if(usePathButtons) {
+            if(pathEntry_ != nullptr) {
+                delete pathEntry_;
+                pathEntry_ = nullptr;
+            }
+            if(pathBar_ == nullptr) {
+                bar = pathBar_ = new Fm::PathBar(this);
+                connect(pathBar_, &Fm::PathBar::chdir, this, &MainWindow::onPathBarChdir);
+                connect(pathBar_, &Fm::PathBar::middleClickChdir, this, &MainWindow::onPathBarMiddleClickChdir);
+                connect(pathBar_, &Fm::PathBar::editingFinished, this, &MainWindow::onResetFocus);
+                if(curPage) {
+                    pathBar_->setPath(currentPage()->path());
+                }
+            }
+        }
+        else {
+            if(pathBar_ != nullptr) {
+                delete pathBar_;
+                pathBar_ = nullptr;
+            }
+            if(pathEntry_ == nullptr) {
+                bar = pathEntry_ = new Fm::PathEdit(this);
+                connect(pathEntry_, &Fm::PathEdit::returnPressed, this, &MainWindow::onPathEntryReturnPressed);
+                if(curPage) {
+                    pathEntry_->setText(curPage->pathName());
+                }
+            }
+        }
+        if(bar != nullptr) {
+            ui.toolBar->insertWidget(ui.actionGo, bar);
+            ui.actionGo->setVisible(!usePathButtons);
+        }
     }
-    ui.toolBar->insertWidget(ui.actionGo, bar);
-    ui.actionGo->setVisible(!usePathButtons);
 }
 
-int MainWindow::addTabWithPage(TabPage* page, Fm::FilePath path) {
-    if(page == nullptr) {
+int MainWindow::addTabWithPage(TabPage* page, ViewFrame* viewFrame, Fm::FilePath path) {
+    if(page == nullptr || viewFrame == nullptr) {
         return -1;
     }
     page->setFileLauncher(&fileLauncher_);
-    int index = ui.stackedWidget->addWidget(page);
+    int index = viewFrame->getStackedWidget()->addWidget(page);
     connect(page, &TabPage::titleChanged, this, &MainWindow::onTabPageTitleChanged);
     connect(page, &TabPage::statusChanged, this, &MainWindow::onTabPageStatusChanged);
     connect(page, &TabPage::openDirRequested, this, &MainWindow::onTabPageOpenDirRequested);
@@ -337,19 +628,19 @@ int MainWindow::addTabWithPage(TabPage* page, Fm::FilePath path) {
     if(path) {
         page->chdir(path, true);
     }
-    ui.tabBar->insertTab(index, page->windowTitle());
+    viewFrame->getTabBar()->insertTab(index, page->windowTitle());
 
     Settings& settings = static_cast<Application*>(qApp)->settings();
     if(!settings.alwaysShowTabs()) {
-        ui.tabBar->setVisible(ui.tabBar->count() > 1);
+        viewFrame->getTabBar()->setVisible(viewFrame->getTabBar()->count() > 1);
     }
     return index;
 }
 
 // add a new tab
-int MainWindow::addTab(Fm::FilePath path) {
+int MainWindow::addTab(Fm::FilePath path, ViewFrame* viewFrame) {
     TabPage* newPage = new TabPage(this);
-    return addTabWithPage(newPage, path);
+    return addTabWithPage(newPage, viewFrame, path);
 }
 
 void MainWindow::toggleMenuBar(bool /*checked*/) {
@@ -374,20 +665,48 @@ void MainWindow::toggleMenuBar(bool /*checked*/) {
 }
 
 void MainWindow::onPathEntryReturnPressed() {
-    QString text = pathEntry_->text();
-    QByteArray utext = text.toLocal8Bit();
-    chdir(Fm::FilePath::fromPathStr(utext.constData()));
+    Fm::PathEdit* pathEntry = pathEntry_;
+    if(pathEntry == nullptr) {
+        pathEntry = static_cast<Fm::PathEdit*>(sender());
+    }
+    if(pathEntry != nullptr) {
+        QString text = pathEntry->text();
+        QByteArray utext = text.toLocal8Bit();
+        chdir(Fm::FilePath::fromPathStr(utext.constData()));
+    }
 }
 
 void MainWindow::onPathBarChdir(const Fm::FilePath& dirPath) {
-    TabPage* page = currentPage();
+    TabPage* page = nullptr;
+    ViewFrame* viewFrame = nullptr;
+    if(pathBar_ != nullptr) {
+        page = currentPage();
+        viewFrame = activeViewFrame_;
+    }
+    else {
+        Fm::PathBar* pathBar = static_cast<Fm::PathBar*>(sender());
+        viewFrame = qobject_cast<ViewFrame*>(pathBar->parentWidget());
+        if(viewFrame != nullptr) {
+            page = currentPage(viewFrame);
+        }
+    }
     if(page && dirPath != page->path()) {
-        chdir(dirPath);
+        chdir(dirPath, viewFrame);
     }
 }
 
 void MainWindow::onPathBarMiddleClickChdir(const Fm::FilePath& dirPath) {
-    addTab(dirPath);
+    ViewFrame* viewFrame = nullptr;
+    if(pathBar_ != nullptr) {
+        viewFrame = activeViewFrame_;
+    }
+    else {
+        Fm::PathBar* pathBar = static_cast<Fm::PathBar*>(sender());
+        viewFrame = qobject_cast<ViewFrame*>(pathBar->parentWidget());
+    }
+    if(viewFrame) {
+        addTab(dirPath, viewFrame);
+    }
 }
 
 void MainWindow::on_actionGoUp_triggered() {
@@ -441,7 +760,7 @@ void MainWindow::on_actionGo_triggered() {
 void MainWindow::on_actionNewTab_triggered() {
     auto path = currentPage()->path();
     int index = addTab(path);
-    ui.tabBar->setCurrentIndex(index);
+    activeViewFrame_->getTabBar()->setCurrentIndex(index);
 }
 
 void MainWindow::on_actionNewWin_triggered() {
@@ -468,7 +787,7 @@ void MainWindow::on_actionNewBlankFile_triggered() {
 }
 
 void MainWindow::on_actionCloseTab_triggered() {
-    closeTab(ui.tabBar->currentIndex());
+    closeTab(activeViewFrame_->getTabBar()->currentIndex());
 }
 
 void MainWindow::on_actionCloseWindow_triggered() {
@@ -551,8 +870,8 @@ void MainWindow::on_actionPreserveView_triggered(bool /*checked*/) {
 
 void MainWindow::on_actionFilter_triggered(bool checked) {
     static_cast<Application*>(qApp)->settings().setShowFilter(checked);
-    // show/hide filter-bars and disable/enable their transience for
-    // all tabs in all windows because this is a global setting
+    // show/hide filter-bars and disable/enable their transience for all tabs
+    // (of all view frames) in all windows because this is a global setting
     QWidgetList windows = static_cast<Application*>(qApp)->topLevelWidgets();
     QWidgetList::iterator it;
     for(it = windows.begin(); it != windows.end(); ++it) {
@@ -560,10 +879,14 @@ void MainWindow::on_actionFilter_triggered(bool checked) {
         if(window->inherits("PCManFM::MainWindow")) {
             MainWindow* mainWindow = static_cast<MainWindow*>(window);
             mainWindow->ui.actionFilter->setChecked(checked); // doesn't call this function
-            int n = mainWindow->ui.stackedWidget->count();
-            for(int i = 0; i < n; ++i) {
-                if(TabPage* page = static_cast<TabPage*>(mainWindow->ui.stackedWidget->widget(i))) {
-                    page->transientFilterBar(!checked);
+            for(int i = 0; i < mainWindow->ui.viewSplitter->count(); ++i) {
+                if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(mainWindow->ui.viewSplitter->widget(i))) {
+                    int n = viewFrame->getStackedWidget()->count();
+                    for(int j = 0; j < n; ++j) {
+                        if(TabPage* page = static_cast<TabPage*>(viewFrame->getStackedWidget()->widget(j))) {
+                            page->transientFilterBar(!checked);
+                        }
+                    }
                 }
             }
         }
@@ -571,11 +894,15 @@ void MainWindow::on_actionFilter_triggered(bool checked) {
 }
 
 void MainWindow::on_actionUnfilter_triggered() {
-    // clear filters for all tabs
-    int n = ui.stackedWidget->count();
-    for(int i = 0; i < n; ++i) {
-        if(TabPage* page = static_cast<TabPage*>(ui.stackedWidget->widget(i))) {
-            page->clearFilter();
+    // clear filters for all tabs (of all view frames)
+    for(int i = 0; i < ui.viewSplitter->count(); ++i) {
+        if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(ui.viewSplitter->widget(i))) {
+            int n = viewFrame->getStackedWidget()->count();
+            for(int j = 0; j < n; ++j) {
+                if(TabPage* page = static_cast<TabPage*>(viewFrame->getStackedWidget()->widget(j))) {
+                    page->clearFilter();
+                }
+            }
         }
     }
 }
@@ -589,25 +916,15 @@ void MainWindow::on_actionShowFilter_triggered() {
 void MainWindow::on_actionLocationBar_triggered(bool checked) {
     if(checked) {
         // show current path in a location bar entry
-        if(pathBar_ != nullptr) {
-            delete pathBar_;
-            pathBar_ = nullptr;
-        }
         createPathBar(false);
-        pathEntry_->setText(currentPage()->pathName());
         static_cast<Application*>(qApp)->settings().setPathBarButtons(false);
     }
 }
 
 void MainWindow::on_actionPathButtons_triggered(bool checked) {
-    if(checked && pathBar_ == nullptr) {
+    if(checked) {
         // show current path as buttons
-        if(pathEntry_ != nullptr) {
-            delete pathEntry_;
-            pathEntry_ = nullptr;
-        }
         createPathBar(true);
-        pathBar_->setPath(currentPage()->path());
         static_cast<Application*>(qApp)->settings().setPathBarButtons(true);
     }
 }
@@ -681,7 +998,10 @@ void MainWindow::on_actionThumbnailView_triggered() {
 }
 
 void MainWindow::onTabBarCloseRequested(int index) {
-    closeTab(index);
+    TabBar* tabBar = static_cast<TabBar*>(sender());
+    if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(tabBar->parentWidget())) {
+        closeTab(index, viewFrame);
+    }
 }
 
 void MainWindow::onResetFocus() {
@@ -691,61 +1011,66 @@ void MainWindow::onResetFocus() {
 }
 
 void MainWindow::onTabBarTabMoved(int from, int to) {
-    // a tab in the tab bar is moved by the user, so we have to move the
-    //  corredponding tab page in the stacked widget to the new position, too.
-    QWidget* page = ui.stackedWidget->widget(from);
-    if(page) {
-        // we're not going to delete the tab page, so here we block signals
-        // to avoid calling the slot onStackedWidgetWidgetRemoved() before
-        // removing the page. Otherwise the page widget will be destroyed.
-        ui.stackedWidget->blockSignals(true);
-        ui.stackedWidget->removeWidget(page);
-        ui.stackedWidget->insertWidget(to, page); // insert the page to the new position
-        ui.stackedWidget->blockSignals(false); // unblock signals
-        ui.stackedWidget->setCurrentWidget(page);
+    TabBar* tabBar = static_cast<TabBar*>(sender());
+    if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(tabBar->parentWidget())) {
+        // a tab in the tab bar is moved by the user, so we have to move the
+        //  corredponding tab page in the stacked widget to the new position, too.
+        QWidget* page = viewFrame->getStackedWidget()->widget(from);
+        if(page) {
+            // we're not going to delete the tab page, so here we block signals
+            // to avoid calling the slot onStackedWidgetWidgetRemoved() before
+            // removing the page. Otherwise the page widget will be destroyed.
+            viewFrame->getStackedWidget()->blockSignals(true);
+            viewFrame->getStackedWidget()->removeWidget(page);
+            viewFrame->getStackedWidget()->insertWidget(to, page); // insert the page to the new position
+            viewFrame->getStackedWidget()->blockSignals(false); // unblock signals
+            viewFrame->getStackedWidget()->setCurrentWidget(page);
+        }
     }
 }
 
 void MainWindow::onFolderUnmounted() {
     TabPage* tabPage = static_cast<TabPage*>(sender());
-    const QList<MountOperation*> ops = ui.sidePane->findChildren<MountOperation*>();
-    if(ops.isEmpty()) { // unmounting is done somewhere else
-        Settings& settings = static_cast<Application*>(qApp)->settings();
-        if(settings.closeOnUnmount()) {
-            ui.stackedWidget->removeWidget(tabPage);
-            delete tabPage;
+    if(ViewFrame* viewFrame = viewFrameForTabPage(tabPage)) {
+        const QList<MountOperation*> ops = ui.sidePane->findChildren<MountOperation*>();
+        if(ops.isEmpty()) { // unmounting is done somewhere else
+            Settings& settings = static_cast<Application*>(qApp)->settings();
+            if(settings.closeOnUnmount()) {
+                viewFrame->getStackedWidget()->removeWidget(tabPage);
+                delete tabPage;
+            }
+            else {
+                tabPage->chdir(Fm::FilePath::homeDir(), viewFrame);
+                updateUIForCurrentPage();
+            }
         }
-        else {
-            tabPage->chdir(Fm::FilePath::homeDir());
-            updateUIForCurrentPage();
-        }
-    }
-    else { // wait for all (un-)mount operations to be finished
-        for(const MountOperation* op : ops) {
-            connect(op, &QObject::destroyed, tabPage, [this, tabPage] {
-                if(ui.sidePane->findChildren<MountOperation*>().isEmpty()) {
-                    Settings& settings = static_cast<Application*>(qApp)->settings();
-                    if(settings.closeOnUnmount()) {
-                        ui.stackedWidget->removeWidget(tabPage);
-                        delete tabPage;
+        else { // wait for all (un-)mount operations to be finished
+            for(const MountOperation* op : ops) {
+                connect(op, &QObject::destroyed, tabPage, [this, tabPage, viewFrame] {
+                    if(ui.sidePane->findChildren<MountOperation*>().isEmpty()) {
+                        Settings& settings = static_cast<Application*>(qApp)->settings();
+                        if(settings.closeOnUnmount()) {
+                            viewFrame->getStackedWidget()->removeWidget(tabPage);
+                            delete tabPage;
+                        }
+                        else {
+                            tabPage->chdir(Fm::FilePath::homeDir(), viewFrame);
+                            updateUIForCurrentPage();
+                        }
                     }
-                    else {
-                        tabPage->chdir(Fm::FilePath::homeDir());
-                        updateUIForCurrentPage();
-                    }
-                }
-            });
+                });
+            }
         }
     }
 }
 
-void MainWindow::closeTab(int index) {
-    QWidget* page = ui.stackedWidget->widget(index);
+void MainWindow::closeTab(int index, ViewFrame* viewFrame) {
+    QWidget* page = viewFrame->getStackedWidget()->widget(index);
     if(page) {
-        ui.stackedWidget->removeWidget(page); // this does not delete the page widget
+        viewFrame->getStackedWidget()->removeWidget(page); // this does not delete the page widget
         delete page;
         // NOTE: we do not remove the tab here.
-        // it'll be donoe in onStackedWidgetWidgetRemoved()
+        // it'll be done in onStackedWidgetWidgetRemoved()
     }
 }
 
@@ -780,8 +1105,23 @@ void MainWindow::closeEvent(QCloseEvent* event) {
 }
 
 void MainWindow::onTabBarCurrentChanged(int index) {
-    ui.stackedWidget->setCurrentIndex(index);
-    updateUIForCurrentPage();
+    TabBar* tabBar = static_cast<TabBar*>(sender());
+    if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(tabBar->parentWidget())) {
+        viewFrame->getStackedWidget()->setCurrentIndex(index);
+        if(viewFrame == activeViewFrame_) {
+            updateUIForCurrentPage();
+        }
+        else {
+            if(TabPage* page = currentPage(viewFrame)) {
+                if(Fm::PathBar* pathBar = qobject_cast<Fm::PathBar*>(viewFrame->getTopBar())) {
+                    pathBar->setPath(page->path());
+                }
+                else if(Fm::PathEdit* pathEntry = qobject_cast<Fm::PathEdit*>(viewFrame->getTopBar())) {
+                    pathEntry->setText(page->pathName());
+                }
+            }
+        }
+    }
 }
 
 void MainWindow::updateStatusBarForCurrentPage() {
@@ -882,20 +1222,32 @@ void MainWindow::updateEditSelectedActions() {
     ui.actionBulkRename->setEnabled(renamable > 1);
 }
 
-void MainWindow::updateUIForCurrentPage() {
+void MainWindow::updateUIForCurrentPage(bool setFocus) {
     TabPage* tabPage = currentPage();
 
     if(tabPage) {
         setWindowTitle(tabPage->windowTitle());
-        if(pathEntry_ != nullptr) {
-            pathEntry_->setText(tabPage->pathName());
+        if(splitView_) {
+            if(Fm::PathBar* pathBar = qobject_cast<Fm::PathBar*>(activeViewFrame_->getTopBar())) {
+                pathBar->setPath(tabPage->path());
+            }
+            else if(Fm::PathEdit* pathEntry = qobject_cast<Fm::PathEdit*>(activeViewFrame_->getTopBar())) {
+                pathEntry->setText(tabPage->pathName());
+            }
         }
-        else if(pathBar_ != nullptr) {
-            pathBar_->setPath(tabPage->path());
+        else {
+            if(pathEntry_ != nullptr) {
+                pathEntry_->setText(tabPage->pathName());
+            }
+            else if(pathBar_ != nullptr) {
+                pathBar_->setPath(tabPage->path());
+            }
         }
         ui.statusbar->showMessage(tabPage->statusText());
         fsInfoLabel_->setText(tabPage->statusText(TabPage::StatusTextFSInfo));
-        tabPage->folderView()->childView()->setFocus();
+        if(setFocus) {
+            tabPage->folderView()->childView()->setFocus();
+        }
 
         // update side pane
         ui.sidePane->setCurrentPath(tabPage->path());
@@ -922,40 +1274,70 @@ void MainWindow::updateUIForCurrentPage() {
 }
 
 void MainWindow::onStackedWidgetWidgetRemoved(int index) {
-    // qDebug("onStackedWidgetWidgetRemoved: %d", index);
-    // need to remove associated tab from tabBar
-    ui.tabBar->removeTab(index);
-    if(ui.tabBar->count() == 0) { // this is the last one
-        deleteLater(); // destroy the whole window
-        // qDebug("delete window");
-    }
-    else {
-        Settings& settings = static_cast<Application*>(qApp)->settings();
-        if(!settings.alwaysShowTabs() && ui.tabBar->count() == 1) {
-            ui.tabBar->setVisible(false);
+    QStackedWidget* sw = static_cast<QStackedWidget*>(sender());
+    if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(sw->parentWidget())) {
+        // qDebug("onStackedWidgetWidgetRemoved: %d", index);
+        // need to remove associated tab from tabBar
+        viewFrame->getTabBar()->removeTab(index);
+        if(viewFrame->getTabBar()->count() == 0) { // this is the last one
+            if(!splitView_) {
+                deleteLater(); // destroy the whole window
+                // qDebug("delete window");
+            }
+            else {
+                // if we are in the split mode and the last tab of a view frame is closed,
+                // remove that view frame and go to the simple mode
+                for(int i = 0; i < ui.viewSplitter->count(); ++i) {
+                    // first find and activate the next view frame
+                    if(ViewFrame* thisViewFrame = qobject_cast<ViewFrame*>(ui.viewSplitter->widget(i))) {
+                        if(thisViewFrame == viewFrame) {
+                            int n = i < ui.viewSplitter->count() - 1 ? i + 1 : 0;
+                            if(ViewFrame* nextViewFrame = qobject_cast<ViewFrame*>(ui.viewSplitter->widget(n))) {
+                                if(activeViewFrame_ != nextViewFrame) {
+                                    activeViewFrame_ = nextViewFrame;
+                                    updateUIForCurrentPage(); // sets the focus too
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+                ui.actionSplitView->setChecked(false);
+                on_actionSplitView_triggered(false);
+            }
+        }
+        else {
+            Settings& settings = static_cast<Application*>(qApp)->settings();
+            if(!settings.alwaysShowTabs() && viewFrame->getTabBar()->count() == 1) {
+                viewFrame->getTabBar()->setVisible(false);
+            }
         }
     }
 }
 
 void MainWindow::onTabPageTitleChanged(QString title) {
     TabPage* tabPage = static_cast<TabPage*>(sender());
-    int index = ui.stackedWidget->indexOf(tabPage);
-    if(index >= 0) {
-        ui.tabBar->setTabText(index, title);
-    }
+    if(ViewFrame* viewFrame = viewFrameForTabPage(tabPage)) {
+        int index = viewFrame->getStackedWidget()->indexOf(tabPage);
+        if(index >= 0) {
+            viewFrame->getTabBar()->setTabText(index, title);
+        }
 
-    if(tabPage == currentPage()) {
-        setWindowTitle(title);
+        if(viewFrame == activeViewFrame_) {
+            if(tabPage == currentPage()) {
+                setWindowTitle(title);
 
-        // Since TabPage::titleChanged is emitted on changing directory,
-        // the enabled state of Paste action should be updated here
-        bool isWritable(false);
-        if(tabPage && tabPage->folder()) {
-            if(auto info = tabPage->folder()->info()) {
-                isWritable = info->isWritable();
+                // Since TabPage::titleChanged is emitted on changing directory,
+                // the enabled state of Paste action should be updated here
+                bool isWritable(false);
+                if(tabPage && tabPage->folder()) {
+                    if(auto info = tabPage->folder()->info()) {
+                        isWritable = info->isWritable();
+                    }
+                }
+                ui.actionPaste->setEnabled(isWritable);
             }
         }
-        ui.actionPaste->setEnabled(isWritable);
     }
 }
 
@@ -989,18 +1371,21 @@ void MainWindow::onTabPageStatusChanged(int type, QString statusText) {
 }
 
 void MainWindow::onTabPageOpenDirRequested(const Fm::FilePath& path, int target) {
-    switch(target) {
-    case OpenInCurrentTab:
-        chdir(path);
-        break;
+    TabPage* tabPage = static_cast<TabPage*>(sender());
+    if(ViewFrame* viewFrame = viewFrameForTabPage(tabPage)){
+        switch(target) {
+        case OpenInCurrentTab:
+            chdir(path, viewFrame);
+            break;
 
-    case OpenInNewTab:
-        addTab(path);
-        break;
+        case OpenInNewTab:
+            addTab(path, viewFrame);
+            break;
 
-    case OpenInNewWindow:
-        (new MainWindow(path))->show();
-        break;
+        case OpenInNewWindow:
+            (new MainWindow(path))->show();
+            break;
+        }
     }
 }
 
@@ -1255,28 +1640,31 @@ void MainWindow::onBackForwardContextMenu(QPoint pos) {
 }
 
 void MainWindow::tabContextMenu(const QPoint& pos) {
-    int tabNum = ui.tabBar->count();
-    if(tabNum <= 1) {
-        return;
-    }
-
-    rightClickIndex_ = ui.tabBar->tabAt(pos);
-    if(rightClickIndex_ < 0) {
-        return;
-    }
-
-    QMenu menu;
-    if(rightClickIndex_ > 0) {
-        menu.addAction(ui.actionCloseLeft);
-    }
-    if(rightClickIndex_ < tabNum - 1) {
-        menu.addAction(ui.actionCloseRight);
-        if(rightClickIndex_ > 0) {
-            menu.addSeparator();
-            menu.addAction(ui.actionCloseOther);
+    TabBar* tabBar = static_cast<TabBar*>(sender());
+    if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(tabBar->parentWidget())) {
+        int tabNum = viewFrame->getTabBar()->count();
+        if(tabNum <= 1) {
+            return;
         }
+
+        rightClickIndex_ = viewFrame->getTabBar()->tabAt(pos);
+        if(rightClickIndex_ < 0) {
+            return;
+        }
+
+        QMenu menu;
+        if(rightClickIndex_ > 0) {
+            menu.addAction(ui.actionCloseLeft);
+        }
+        if(rightClickIndex_ < tabNum - 1) {
+            menu.addAction(ui.actionCloseRight);
+            if(rightClickIndex_ > 0) {
+                menu.addSeparator();
+                menu.addAction(ui.actionCloseOther);
+            }
+        }
+        menu.exec(viewFrame->getTabBar()->mapToGlobal(pos));
     }
-    menu.exec(ui.tabBar->mapToGlobal(pos));
 }
 
 void MainWindow::closeLeftTabs() {
@@ -1290,19 +1678,30 @@ void MainWindow::closeRightTabs() {
     if(rightClickIndex_ < 0) {
         return;
     }
-    while(rightClickIndex_ < ui.tabBar->count() - 1) {
+    while(rightClickIndex_ < activeViewFrame_->getTabBar()->count() - 1) {
         closeTab(rightClickIndex_ + 1);
     }
 }
 
 void MainWindow::focusPathEntry() {
     // use text entry for the path bar
-    if(pathEntry_ != nullptr) {
-        pathEntry_->setFocus();
-        pathEntry_->selectAll();
+    if(splitView_) {
+        if(Fm::PathBar* pathBar = qobject_cast<Fm::PathBar*>(activeViewFrame_->getTopBar())) {
+            pathBar->openEditor();
+        }
+        else if(Fm::PathEdit* pathEntry = qobject_cast<Fm::PathEdit*>(activeViewFrame_->getTopBar())) {
+            pathEntry->setFocus();
+            pathEntry->selectAll();
+        }
     }
-    else if(pathBar_ != nullptr) {  // use button-style path bar
-        pathBar_->openEditor();
+    else{
+        if(pathEntry_ != nullptr) {
+            pathEntry_->setFocus();
+            pathEntry_->selectAll();
+        }
+        else if(pathBar_ != nullptr) {  // use button-style path bar
+            pathBar_->openEditor();
+        }
     }
 }
 
@@ -1322,7 +1721,7 @@ void MainWindow::dropEvent(QDropEvent* event) {
 void MainWindow::dropTab() {
     if(lastActive_ == nullptr // impossible
        || lastActive_ == this) { // don't drop on the same window
-        ui.tabBar->finishMouseMoveEvent();
+        activeViewFrame_->getTabBar()->finishMouseMoveEvent();
         return;
     }
 
@@ -1334,21 +1733,21 @@ void MainWindow::dropTab() {
 
         // release mouse before tab removal because otherwise, the source tabbar
         // might not be updated properly with tab reordering during a fast drag-and-drop
-        lastActive_->ui.tabBar->releaseMouse();
+        lastActive_->activeViewFrame_->getTabBar()->releaseMouse();
 
-        QWidget* page = lastActive_->ui.stackedWidget->currentWidget();
-        lastActive_->ui.stackedWidget->removeWidget(page);
-        int index = addTabWithPage(dropPage);
-        ui.tabBar->setCurrentIndex(index);
+        QWidget* page = lastActive_->activeViewFrame_->getStackedWidget()->currentWidget();
+        lastActive_->activeViewFrame_->getStackedWidget()->removeWidget(page);
+        int index = addTabWithPage(dropPage, activeViewFrame_);
+        activeViewFrame_->getTabBar()->setCurrentIndex(index);
     }
     else {
-        ui.tabBar->finishMouseMoveEvent(); // impossible
+        activeViewFrame_->getTabBar()->finishMouseMoveEvent(); // impossible
     }
 }
 
 void MainWindow::detachTab() {
-    if (ui.stackedWidget->count() == 1) { // don't detach a single tab
-        ui.tabBar->finishMouseMoveEvent();
+    if (activeViewFrame_->getStackedWidget()->count() == 1) { // don't detach a single tab
+        activeViewFrame_->getTabBar()->finishMouseMoveEvent();
         return;
     }
 
@@ -1357,16 +1756,16 @@ void MainWindow::detachTab() {
     if(dropPage) {
         disconnect(dropPage, nullptr, this, nullptr);
 
-        ui.tabBar->releaseMouse(); // as in dropTab()
+        activeViewFrame_->getTabBar()->releaseMouse(); // as in dropTab()
 
-        QWidget* page = ui.stackedWidget->currentWidget();
-        ui.stackedWidget->removeWidget(page);
+        QWidget* page = activeViewFrame_->getStackedWidget()->currentWidget();
+        activeViewFrame_->getStackedWidget()->removeWidget(page);
         MainWindow* newWin = new MainWindow();
-        newWin->addTabWithPage(dropPage);
+        newWin->addTabWithPage(dropPage, newWin->activeViewFrame_);
         newWin->show();
     }
     else {
-        ui.tabBar->finishMouseMoveEvent(); // impossible
+        activeViewFrame_->getTabBar()->finishMouseMoveEvent(); // impossible
     }
 }
 
@@ -1381,25 +1780,19 @@ void MainWindow::updateFromSettings(Settings& settings) {
     ui.sidePane->setIconSize(QSize(settings.sidePaneIconSize(), settings.sidePaneIconSize()));
 
     // tabs
-    ui.tabBar->setTabsClosable(settings.showTabClose());
-    ui.tabBar->setVisible(settings.alwaysShowTabs() || (ui.tabBar->count() > 1));
-    if(ui.verticalLayout->indexOf(ui.tabBar) > -1) {
-        if(!settings.fullWidthTabBar()) {
-            ui.verticalLayout->removeWidget(ui.tabBar);
-            ui.verticalLayout_2->insertWidget(0, ui.tabBar);
+    for(int i = 0; i < ui.viewSplitter->count(); ++i) {
+        if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(ui.viewSplitter->widget(i))) {
+            viewFrame->getTabBar()->setTabsClosable(settings.showTabClose());
+            viewFrame->getTabBar()->setVisible(settings.alwaysShowTabs() || (viewFrame->getTabBar()->count() > 1));
+
+            // all tab pages
+            int n = viewFrame->getStackedWidget()->count();
+
+            for(int j = 0; j < n; ++j) {
+                TabPage* page = static_cast<TabPage*>(viewFrame->getStackedWidget()->widget(j));
+                page->updateFromSettings(settings);
+            }
         }
-    }
-    else if(ui.verticalLayout_2->indexOf(ui.tabBar) > -1 && settings.fullWidthTabBar()) {
-        ui.verticalLayout_2->removeWidget(ui.tabBar);
-        ui.verticalLayout->insertWidget(0, ui.tabBar);
-    }
-
-    // all tab pages
-    int n = ui.stackedWidget->count();
-
-    for(int i = 0; i < n; ++i) {
-        TabPage* page = static_cast<TabPage*>(ui.stackedWidget->widget(i));
-        page->updateFromSettings(settings);
     }
 }
 
@@ -1477,22 +1870,22 @@ void MainWindow::on_actionOpenTerminal_triggered() {
 }
 
 void MainWindow::onShortcutNextTab() {
-    int current = ui.tabBar->currentIndex();
-    if(current < ui.tabBar->count() - 1) {
-        ui.tabBar->setCurrentIndex(current + 1);
+    int current = activeViewFrame_->getTabBar()->currentIndex();
+    if(current < activeViewFrame_->getTabBar()->count() - 1) {
+        activeViewFrame_->getTabBar()->setCurrentIndex(current + 1);
     }
     else {
-        ui.tabBar->setCurrentIndex(0);
+        activeViewFrame_->getTabBar()->setCurrentIndex(0);
     }
 }
 
 void MainWindow::onShortcutPrevTab() {
-    int current = ui.tabBar->currentIndex();
+    int current = activeViewFrame_->getTabBar()->currentIndex();
     if(current > 0) {
-        ui.tabBar->setCurrentIndex(current - 1);
+        activeViewFrame_->getTabBar()->setCurrentIndex(current - 1);
     }
     else {
-        ui.tabBar->setCurrentIndex(ui.tabBar->count() - 1);
+        activeViewFrame_->getTabBar()->setCurrentIndex(activeViewFrame_->getTabBar()->count() - 1);
     }
 }
 
@@ -1521,8 +1914,8 @@ void MainWindow::onShortcutJumpToTab() {
     else {
         index = keyValue - '1';
     }
-    if(index < ui.tabBar->count()) {
-        ui.tabBar->setCurrentIndex(index);
+    if(index < activeViewFrame_->getTabBar()->count()) {
+        activeViewFrame_->getTabBar()->setCurrentIndex(index);
     }
 }
 

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -481,150 +481,45 @@ only if there are more than one tab.</string>
              </widget>
             </item>
             <item row="1" column="0" colspan="2">
-             <widget class="QCheckBox" name="fullWidthTabbar">
-              <property name="toolTip">
-               <string>If unchecked, the tab bar will be positioned only
-above the folder-view and not above the left pane.</string>
-              </property>
-              <property name="text">
-               <string>Fullwidth tab bar</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0" colspan="2">
              <widget class="QCheckBox" name="showTabClose">
               <property name="text">
                <string>Show 'Close' buttons on tabs	</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="0" colspan="2">
+            <item row="2" column="0" colspan="2">
              <widget class="QCheckBox" name="rememberWindowSize">
               <property name="text">
                <string>Remember the size of the last closed window</string>
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
+            <item row="3" column="0">
              <widget class="QLabel" name="label_12">
               <property name="text">
                <string>Default width of new windows:</string>
               </property>
              </widget>
             </item>
-            <item row="4" column="1">
+            <item row="3" column="1">
              <widget class="QSpinBox" name="fixedWindowWidth">
               <property name="maximum">
                <number>32768</number>
               </property>
              </widget>
             </item>
-            <item row="5" column="0">
+            <item row="4" column="0">
              <widget class="QLabel" name="label_13">
               <property name="text">
                <string>Default height of new windows:</string>
               </property>
              </widget>
             </item>
-            <item row="5" column="1">
+            <item row="4" column="1">
              <widget class="QSpinBox" name="fixedWindowHeight">
               <property name="maximum">
                <number>32768</number>
               </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="groupBox_10">
-           <property name="title">
-            <string>Show in places</string>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_10">
-            <item>
-             <widget class="QListWidget" name="showInPlaces">
-              <item>
-               <property name="text">
-                <string>Home</string>
-               </property>
-               <property name="checkState">
-                <enum>Unchecked</enum>
-               </property>
-               <property name="icon">
-                <iconset theme="user-home">
-                 <normaloff/>
-                </iconset>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Desktop</string>
-               </property>
-               <property name="checkState">
-                <enum>Unchecked</enum>
-               </property>
-               <property name="icon">
-                <iconset theme="user-desktop">
-                 <normaloff/>
-                </iconset>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Trash can</string>
-               </property>
-               <property name="checkState">
-                <enum>Unchecked</enum>
-               </property>
-               <property name="icon">
-                <iconset theme="user-trash">
-                 <normaloff/>
-                </iconset>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Computer</string>
-               </property>
-               <property name="checkState">
-                <enum>Unchecked</enum>
-               </property>
-               <property name="icon">
-                <iconset theme="computer">
-                 <normaloff/>
-                </iconset>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Applications</string>
-               </property>
-               <property name="checkState">
-                <enum>Unchecked</enum>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Devices</string>
-               </property>
-               <property name="checkState">
-                <enum>Unchecked</enum>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Network</string>
-               </property>
-               <property name="checkState">
-                <enum>Unchecked</enum>
-               </property>
-               <property name="icon">
-                <iconset theme="folder-network">
-                 <normaloff/>
-                </iconset>
-               </property>
-              </item>
              </widget>
             </item>
            </layout>

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -181,14 +181,10 @@ void PreferencesDialog::initDisplayPage(Settings& settings) {
 
 void PreferencesDialog::initUiPage(Settings& settings) {
     ui.alwaysShowTabs->setChecked(settings.alwaysShowTabs());
-    ui.fullWidthTabbar->setChecked(settings.fullWidthTabBar());
     ui.showTabClose->setChecked(settings.showTabClose());
     ui.rememberWindowSize->setChecked(settings.rememberWindowSize());
     ui.fixedWindowWidth->setValue(settings.fixedWindowWidth());
     ui.fixedWindowHeight->setValue(settings.fixedWindowHeight());
-
-    // FIXME: Hide options that we don't support yet.
-    ui.showInPlaces->parentWidget()->hide();
 }
 
 void PreferencesDialog::initBehaviorPage(Settings& settings) {
@@ -315,7 +311,6 @@ void PreferencesDialog::applyDisplayPage(Settings& settings) {
 
 void PreferencesDialog::applyUiPage(Settings& settings) {
     settings.setAlwaysShowTabs(ui.alwaysShowTabs->isChecked());
-    settings.setFullWidthTabBar(ui.fullWidthTabbar->isChecked());
     settings.setShowTabClose(ui.showTabClose->isChecked());
     settings.setRememberWindowSize(ui.rememberWindowSize->isChecked());
     settings.setFixedWindowWidth(ui.fixedWindowWidth->value());

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -88,7 +88,7 @@ Settings::Settings():
     splitterPos_(120),
     sidePaneMode_(Fm::SidePane::ModePlaces),
     showMenuBar_(true),
-    fullWidthTabBar_(true),
+    splitView_(false),
     viewMode_(Fm::FolderView::IconMode),
     showHidden_(false),
     sortOrder_(Qt::AscendingOrder),
@@ -302,7 +302,7 @@ bool Settings::loadFile(QString filePath) {
     splitterPos_ = settings.value("SplitterPos", 150).toInt();
     sidePaneMode_ = sidePaneModeFromString(settings.value("SidePaneMode").toString());
     showMenuBar_ = settings.value("ShowMenuBar", true).toBool();
-    fullWidthTabBar_ = settings.value("FullWidthTabBar", true).toBool();
+    splitView_ = settings.value("SplitView", false).toBool();
     pathBarButtons_ = settings.value("PathBarButtons", true).toBool();
     settings.endGroup();
 
@@ -434,7 +434,7 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue("SplitterPos", splitterPos_);
     settings.setValue("SidePaneMode", sidePaneModeToString(sidePaneMode_));
     settings.setValue("ShowMenuBar", showMenuBar_);
-    settings.setValue("FullWidthTabBar", fullWidthTabBar_);
+    settings.setValue("SplitView", splitView_);
     settings.setValue("PathBarButtons", pathBarButtons_);
     settings.endGroup();
 

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -464,12 +464,12 @@ public:
         showMenuBar_ = showMenuBar;
     }
 
-    bool fullWidthTabBar() const {
-        return fullWidthTabBar_;
+    bool splitView() const {
+        return splitView_;
     }
 
-    void setFullWidthTabBar(bool fullWith) {
-        fullWidthTabBar_ = fullWith;
+    void setSplitView(bool split) {
+        splitView_ = split;
     }
 
     Fm::FolderView::ViewMode viewMode() const {
@@ -918,7 +918,7 @@ private:
     int splitterPos_;
     Fm::SidePane::Mode sidePaneMode_;
     bool showMenuBar_;
-    bool fullWidthTabBar_;
+    bool splitView_;
 
     Fm::FolderView::ViewMode viewMode_;
     bool showHidden_;

--- a/pcmanfm/tabbar.cpp
+++ b/pcmanfm/tabbar.cpp
@@ -29,23 +29,31 @@ namespace PCManFM {
 
 TabBar::TabBar(QWidget *parent):
     QTabBar(parent),
-    dragStarted_(false)
+    dragStarted_(false),
+    detachable_(true)
 {
 }
 
 void TabBar::mousePressEvent(QMouseEvent *event) {
     QTabBar::mousePressEvent (event);
-    if(event->button() == Qt::LeftButton
-       && tabAt(event->pos()) > -1) {
-        dragStartPosition_ = event->pos();
+    if(detachable_){
+        if(event->button() == Qt::LeftButton
+        && tabAt(event->pos()) > -1) {
+            dragStartPosition_ = event->pos();
+        }
+        dragStarted_ = false;
     }
-    dragStarted_ = false;
 }
 
 void TabBar::mouseMoveEvent(QMouseEvent *event)
 {
+    if(!detachable_) {
+        QTabBar::mouseMoveEvent(event);
+        return;
+    }
+
     if(!dragStartPosition_.isNull()
-       && (event->pos() - dragStartPosition_).manhattanLength() < QApplication::startDragDistance()) {
+       && (event->pos() - dragStartPosition_).manhattanLength() >= QApplication::startDragDistance()) {
         dragStarted_ = true;
     }
 
@@ -102,7 +110,7 @@ void TabBar::mouseReleaseEvent(QMouseEvent *event) {
 
 // Let the main window receive dragged tabs!
 void TabBar::dragEnterEvent(QDragEnterEvent *event) {
-    if(event->mimeData()->hasFormat("application/pcmanfm-qt-tab")) {
+    if(detachable_ && event->mimeData()->hasFormat("application/pcmanfm-qt-tab")) {
         event->ignore();
     }
 }

--- a/pcmanfm/tabbar.h
+++ b/pcmanfm/tabbar.h
@@ -35,6 +35,10 @@ public:
     void finishMouseMoveEvent();
     void releaseMouse();
 
+    void setDetachable(bool detachable) {
+        detachable_ = detachable;
+    }
+
 Q_SIGNALS:
     void tabDetached();
 
@@ -48,6 +52,7 @@ protected:
 private:
     QPoint dragStartPosition_;
     bool dragStarted_;
+    bool detachable_;
 };
 
 }

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -72,6 +72,7 @@ protected:
         Q_EMIT lostFocus();
         QLineEdit::focusOutEvent(event);
     }
+    virtual void keyPressEvent(QKeyEvent* event) override;
 
 Q_SIGNALS:
     void lostFocus();


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/104

The split view can be toggled by `F6`. Switching between view frames can be done by the `Tab` key. Also, when the single tab of a split view frame is closed, the split mode is changed to the simple one.

For now, the split view has only two frames but the code is written in such way that more frames will be possible later.

Please note that the "full-width tab bar" was incompatible with the code of split view and so, is removed. IMHO, preserving it would require an unmaintainable code.