### PR TITLE
Split-view fixes for inactive windows and tabbar

### DIFF
--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -204,6 +204,7 @@ protected Q_SLOTS:
     void onFolderUnmounted();
 
     void tabContextMenu(const QPoint& pos);
+    void onTabBarClicked(int index);
     void closeLeftTabs();
     void closeRightTabs();
     void closeOtherTabs() {


### PR DESCRIPTION
This patch fixes 2 issues in the split view:

 * When the active view frame of an *inactive* window was removed, the background of the other view didn't change to normal.
 * When the tab bar of an inactive view frame was clicked, its view wasn't focused.

In addition:

 * Instead of comparing whole palettes, which can be "slow", only their base colors are compared.
 * Tab bars are made non-focusable for better focusing of views.
 * An old comment (about hiding network) is removed because it wasn't pertinent anymore.