### PR TITLE
Ensure tab drag source is ours

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -1724,7 +1724,9 @@ void MainWindow::focusPathEntry() {
 }
 
 void MainWindow::dragEnterEvent(QDragEnterEvent* event) {
-    if(event->mimeData()->hasFormat("application/pcmanfm-qt-tab")) {
+    if(event->mimeData()->hasFormat("application/pcmanfm-qt-tab")
+       // ensure that the tab drag source is ours (and not a root window, for example)
+       && lastActive_ && lastActive_->isActiveWindow()) {
         event->acceptProposedAction();
     }
 }


### PR DESCRIPTION
Otherwise, when a tab of a root instance is dropped into a user window (or conversely), strange things might happen (no crash though).