### PR TITLE
Optional Desktop shortcuts

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -454,6 +454,59 @@ A space is also reserved for 3 lines of text.</string>
       </attribute>
       <layout class="QVBoxLayout" name="advancedPageLayout">
        <item>
+        <widget class="QGroupBox" name="groupBox_6">
+         <property name="title">
+          <string>Visible Shortcuts</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <widget class="QCheckBox" name="homeBox">
+            <property name="text">
+             <string>Home</string>
+            </property>
+            <property name="icon">
+             <iconset theme="user-home">
+              <normaloff>.</normaloff>.</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="trashBox">
+            <property name="text">
+             <string>Trash</string>
+            </property>
+            <property name="icon">
+             <iconset theme="user-trash">
+              <normaloff>.</normaloff>.</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="computerBox">
+            <property name="text">
+             <string>Computer</string>
+            </property>
+            <property name="icon">
+             <iconset theme="computer">
+              <normaloff>.</normaloff>.</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="networkBox">
+            <property name="text">
+             <string>Network</string>
+            </property>
+            <property name="icon">
+             <iconset theme="folder-network">
+              <normaloff>.</normaloff>.</iconset>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="groupBox_4">
          <property name="title">
           <string>Window Manager</string>

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -104,6 +104,13 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
   ui.backgroundColor->setColor(settings.desktopBgColor());
   ui.textColor->setColor(settings.desktopFgColor());
   ui.shadowColor->setColor(settings.desktopShadowColor());
+
+  const QStringList ds = settings.desktopShortcuts();
+  ui.homeBox->setChecked(ds.contains(QLatin1String("Home")));
+  ui.trashBox->setChecked(ds.contains(QLatin1String("Trash")));
+  ui.computerBox->setChecked(ds.contains(QLatin1String("Computer")));
+  ui.networkBox->setChecked(ds.contains(QLatin1String("Network")));
+
   ui.showWmMenu->setChecked(settings.showWmMenu());
 
   connect(ui.buttonBox->button(QDialogButtonBox::Apply), &QPushButton::clicked,
@@ -167,6 +174,22 @@ void DesktopPreferencesDialog::applySettings()
   settings.setDesktopBgColor(ui.backgroundColor->color());
   settings.setDesktopFgColor(ui.textColor->color());
   settings.setDesktopShadowColor(ui.shadowColor->color());
+
+  QStringList ds;
+  if(ui.homeBox->isChecked()) {
+      ds << QLatin1String("Home");
+  }
+  if(ui.trashBox->isChecked()) {
+      ds << QLatin1String("Trash");
+  }
+  if(ui.computerBox->isChecked()) {
+      ds << QLatin1String("Computer");
+  }
+  if(ui.networkBox->isChecked()) {
+      ds << QLatin1String("Network");
+  }
+  settings.setDesktopShortcuts(ds);
+
   settings.setShowWmMenu(ui.showWmMenu->isChecked());
 
   settings.setDesktopCellMargins(QSize(ui.hMargin->value(), ui.vMargin->value()));

--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -290,7 +290,7 @@ void DesktopWindow::createTrashShortcut(int items) {
     else {
         name = tr("Trash (Empty)");
     }
-    g_key_file_set_string(kf, "Desktop Entry", "Name", name.toLatin1().constData());
+    g_key_file_set_string(kf, "Desktop Entry", "Name", name.toStdString().c_str());
 
     auto path = Fm::FilePath::fromLocalPath(XdgDir::readDesktopDir().toStdString().c_str()).localPath();
     auto trash_can = Fm::CStrPtr{g_build_filename(path.get(), "trash-can.desktop", nullptr)};
@@ -303,7 +303,8 @@ void DesktopWindow::createHomeShortcut() {
     g_key_file_set_string(kf, "Desktop Entry", "Type", "Application");
     g_key_file_set_string(kf, "Desktop Entry", "Exec", "pcmanfm-qt");
     g_key_file_set_string(kf, "Desktop Entry", "Icon", "user-home");
-    g_key_file_set_string(kf, "Desktop Entry", "Name", "Home");
+    const QString name = tr("Home");
+    g_key_file_set_string(kf, "Desktop Entry", "Name", name.toStdString().c_str());
 
     auto path = Fm::FilePath::fromLocalPath(XdgDir::readDesktopDir().toStdString().c_str()).localPath();
     auto trash_can = Fm::CStrPtr{g_build_filename(path.get(), "user-home.desktop", nullptr)};
@@ -316,7 +317,8 @@ void DesktopWindow::createComputerShortcut() {
     g_key_file_set_string(kf, "Desktop Entry", "Type", "Application");
     g_key_file_set_string(kf, "Desktop Entry", "Exec", "pcmanfm-qt computer:///");
     g_key_file_set_string(kf, "Desktop Entry", "Icon", "computer");
-    g_key_file_set_string(kf, "Desktop Entry", "Name", "Computer");
+    const QString name = tr("Computer");
+    g_key_file_set_string(kf, "Desktop Entry", "Name", name.toStdString().c_str());
 
     auto path = Fm::FilePath::fromLocalPath(XdgDir::readDesktopDir().toStdString().c_str()).localPath();
     auto trash_can = Fm::CStrPtr{g_build_filename(path.get(), "computer.desktop", nullptr)};
@@ -329,7 +331,8 @@ void DesktopWindow::createNetworkShortcut() {
     g_key_file_set_string(kf, "Desktop Entry", "Type", "Application");
     g_key_file_set_string(kf, "Desktop Entry", "Exec", "pcmanfm-qt network:///");
     g_key_file_set_string(kf, "Desktop Entry", "Icon", "folder-network");
-    g_key_file_set_string(kf, "Desktop Entry", "Name", "Network");
+    const QString name = tr("Network");
+    g_key_file_set_string(kf, "Desktop Entry", "Name", name.toStdString().c_str());
 
     auto path = Fm::FilePath::fromLocalPath(XdgDir::readDesktopDir().toStdString().c_str()).localPath();
     auto trash_can = Fm::CStrPtr{g_build_filename(path.get(), "network.desktop", nullptr)};

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -132,6 +132,8 @@ protected Q_SLOTS:
     void onDeleteActivated();
     void onFilePropertiesActivated();
 
+    void updateTrashIcon();
+
 private:
     void removeBottomGap();
     void addDesktopActions(QMenu* menu);
@@ -139,6 +141,17 @@ private:
     void paintDropIndicator();
     void stickToPosition(const QString& file, QPoint& pos, const QRect& workArea, const QSize& grid);
     static void alignToGrid(QPoint& pos, const QPoint& topLeft, const QSize& grid, const int spacing);
+
+    void updateShortcutsFromSettings(Settings& settings);
+    void createTrashShortcut(int items);
+    void createHomeShortcut();
+    void createComputerShortcut();
+    void createNetworkShortcut();
+
+    void createTrash();
+    static void onTrashChanged(GFileMonitor* monitor, GFile* gf, GFile* other, GFileMonitorEvent evt, DesktopWindow* pThis);
+    void trustOurDesktopShortcut(std::shared_ptr<const Fm::FileInfo> file);
+    bool isTrashCan(std::shared_ptr<const Fm::FileInfo> file);
 
 private:
     Fm::ProxyFolderModel* proxyModel_;
@@ -168,6 +181,8 @@ private:
     QTimer* selectionTimer_;
 
     QRect dropRect_;
+
+    GFileMonitor* trashMonitor_;
 };
 
 }

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -231,6 +231,7 @@ bool Settings::loadFile(QString filePath) {
         desktopFont_ = QApplication::font();
     }
     desktopIconSize_ = settings.value("DesktopIconSize", 48).toInt();
+    desktopShortcuts_ = settings.value("DesktopShortcuts").toStringList();
     showWmMenu_ = settings.value("ShowWmMenu", false).toBool();
     desktopShowHidden_ = settings.value("ShowHidden", false).toBool();
     desktopHideItems_ = settings.value("HideItems", false).toBool();
@@ -361,6 +362,7 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue("ShadowColor", desktopShadowColor_.name());
     settings.setValue("Font", desktopFont_.toString());
     settings.setValue("DesktopIconSize", desktopIconSize_);
+    settings.setValue("DesktopShortcuts", desktopShortcuts_);
     settings.setValue("ShowWmMenu", showWmMenu_);
     settings.setValue("ShowHidden", desktopShowHidden_);
     settings.setValue("HideItems", desktopHideItems_);

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -313,6 +313,14 @@ public:
         desktopIconSize_ = desktopIconSize;
     }
 
+    QStringList desktopShortcuts() const {
+        return desktopShortcuts_;
+    }
+
+    void setDesktopShortcuts(const QStringList& list) {
+        desktopShortcuts_ = list;
+    }
+
     bool showWmMenu() const {
         return showWmMenu_;
     }
@@ -899,6 +907,7 @@ private:
     QColor desktopShadowColor_;
     QFont desktopFont_;
     int desktopIconSize_;
+    QStringList desktopShortcuts_;
     bool showWmMenu_;
 
     bool desktopShowHidden_;


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt/issues/812

They can be added/removed in `Desktop Preferences` → `Advanced` (the tab got a real gob, at last). By default, there is no shortcut but distros can change that easily.

The Trash shortcut can empty Trash and files can be dropped into it (the drop indicator is shown). Its icon and text are changed when needed.

NOTES:

  * When seen inside a pcmanfm-qt *window*, the shortcuts are like ordinary files but if deleted in any way, they will be recreated with the app restart.
  * If there are already desktop entries with the same file-names, they will be updated.
  * It isn't easy to test this patch under all possible circumstances. So, IMO, it should be tested for a while.