### PR TITLE
Don't update desktop trash faster than 4 times every sec

### DIFF
--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -182,6 +182,7 @@ private:
 
     QRect dropRect_;
 
+    QTimer* trashUpdateTimer_;
     GFileMonitor* trashMonitor_;
 };
 


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/811

Because too many writes can block input and the desktop isn't refreshed more frequently either.

The result was quite acceptable when I dropped ~5000 files (chromium cache) into desktop trash and then emptied it.

NOTE: A part of https://github.com/lxqt/pcmanfm-qt/issues/811 isn't related to desktop trash and should be reported again.