### PR TITLE
A Tool menu item and shortcut to copy full path

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -39,6 +39,7 @@
 #include <QMimeData>
 #include <QPaintEvent>
 #include <QStandardPaths>
+#include <QClipboard>
 
 #include "./application.h"
 #include "mainwindow.h"
@@ -153,6 +154,9 @@ DesktopWindow::DesktopWindow(int screenNum):
 
     shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_C), this); // copy
     connect(shortcut, &QShortcut::activated, this, &DesktopWindow::onCopyActivated);
+
+    shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_C), this); // copy full path
+    connect(shortcut, &QShortcut::activated, this, &DesktopWindow::onCopyFullPathActivated);
 
     shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_V), this); // paste
     connect(shortcut, &QShortcut::activated, this, &DesktopWindow::onPasteActivated);
@@ -1320,6 +1324,16 @@ void DesktopWindow::onCopyActivated() {
     auto paths = selectedFilePaths();
     if(!paths.empty()) {
         Fm::copyFilesToClipboard(paths);
+    }
+}
+
+void DesktopWindow::onCopyFullPathActivated() {
+    if(desktopHideItems_) {
+        return;
+    }
+    auto paths = selectedFilePaths();
+    if(paths.size() == 1) {
+        QApplication::clipboard()->setText(QString(paths.front().toString().get()), QClipboard::Clipboard);
     }
 }
 

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -126,6 +126,7 @@ protected Q_SLOTS:
     // file operations
     void onCutActivated();
     void onCopyActivated();
+    void onCopyFullPathActivated();
     void onPasteActivated();
     void onRenameActivated();
     void onBulkRenameActivated();

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -205,6 +205,7 @@
     </property>
     <addaction name="actionOpenTerminal"/>
     <addaction name="actionOpenAsRoot"/>
+    <addaction name="actionCopyFullPath"/>
     <addaction name="actionFindFiles"/>
    </widget>
    <addaction name="menu_File"/>
@@ -838,6 +839,14 @@
    </property>
    <property name="shortcut">
     <string>F6</string>
+   </property>
+  </action>
+  <action name="actionCopyFullPath">
+   <property name="text">
+    <string>&amp;Copy Full Path</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+C</string>
    </property>
   </action>
  </widget>

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -32,6 +32,7 @@
 #include <QSettings>
 #include <QMimeData>
 #include <QStandardPaths>
+#include <QClipboard>
 #include <QDebug>
 
 #include "tabpage.h"
@@ -1222,6 +1223,7 @@ void MainWindow::updateEditSelectedActions() {
                 break;
             }
         }
+        ui.actionCopyFullPath->setEnabled(files.size() == 1);
     }
     ui.actionCopy->setEnabled(hasAccessible);
     ui.actionCut->setEnabled(hasDeletable);
@@ -1896,6 +1898,16 @@ void MainWindow::on_actionOpenTerminal_triggered() {
     if(page) {
         Application* app = static_cast<Application*>(qApp);
         app->openFolderInTerminal(page->path());
+    }
+}
+
+void MainWindow::on_actionCopyFullPath_triggered() {
+    TabPage* page = currentPage();
+    if(page) {
+        auto paths = page->selectedFilePaths();
+        if(paths.size() == 1) {
+            QApplication::clipboard()->setText(QString(paths.front().toString().get()), QClipboard::Clipboard);
+        }
     }
 }
 

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -169,6 +169,7 @@ protected Q_SLOTS:
 
     void on_actionOpenTerminal_triggered();
     void on_actionOpenAsRoot_triggered();
+    void on_actionCopyFullPath_triggered();
     void on_actionFindFiles_triggered();
 
     void on_actionAbout_triggered();


### PR DESCRIPTION
It's enabled with its shortcut when one and only one file is selected (inside the focused split-view if any). Its shortcut works on Desktop too when Desktop has focus.