### PR TITLE
No desktop drop indicator on self

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -1546,7 +1546,9 @@ void DesktopWindow::childDragMoveEvent(QDragMoveEvent* e) {
     QRect oldDropRect = dropRect_;
     dropRect_ = QRect();
     QModelIndex index = listView_->indexAt(e->pos());
-    if(index.isValid() && index.model()) {
+    QModelIndex curIndx = listView_->currentIndex();
+    if(index.isValid() && curIndx.isValid() && curIndx != index // not on self
+       && index.model()) {
         QVariant data = index.model()->data(index, Fm::FolderModel::Role::FileInfoRole);
         auto info = data.value<std::shared_ptr<const Fm::FileInfo>>();
         if(info && (info->isDir() || isTrashCan(info))) {


### PR DESCRIPTION
When a folder is dragged over itself on Desktop, there should be no drop indicator (rectangle) because, on Desktop, dropping on self means sticking to the current position. The same is true for the Trash item.

Previously, when a Desktop folder was dragged and dropped on itself, the drop ndicator remained intact, unless another desktop item was dragged.