### PR TITLE
More natural DND on Desktop

### DIFF
--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -140,7 +140,7 @@ private:
     void addDesktopActions(QMenu* menu);
     void paintBackground(QPaintEvent* event);
     void paintDropIndicator();
-    void stickToPosition(const std::string& file, QPoint& pos, const QRect& workArea, const QSize& grid);
+    bool stickToPosition(const std::string& file, QPoint& pos, const QRect& workArea, const QSize& grid, bool reachedLastCell = false);
     static void alignToGrid(QPoint& pos, const QPoint& topLeft, const QSize& grid, const int spacing);
 
     void updateShortcutsFromSettings(Settings& settings);


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/861

With this patch, items can be comfortably moved or dragged and dropped on desktop, without unnatural jumps -- especially when they are moved toward the right or bottom screen edge.

The code comment of `DesktopWindow::stickToPosition()` serves as a short explanation.