### PR TITLE
Removed QDesktopWidget

### DIFF
--- a/pcmanfm/application.h
+++ b/pcmanfm/application.h
@@ -102,20 +102,20 @@ protected Q_SLOTS:
 
     void onLastWindowClosed();
     void onSaveStateRequest(QSessionManager& manager);
-    void onScreenResized(int num);
-    void onScreenCountChanged(int newCount);
     void initVolumeManager();
 
     void onVirtualGeometryChanged(const QRect& rect);
+    void onAvailableGeometryChanged(const QRect& rect);
     void onScreenDestroyed(QObject* screenObj);
     void onScreenAdded(QScreen* newScreen);
+    void onScreenRemoved(QScreen* oldScreen);
     void reloadDesktopsAsNeeded();
 
     void onFindFileAccepted();
     void onConnectToServerAccepted();
 
 protected:
-    virtual bool eventFilter(QObject* watched, QEvent* event);
+    //virtual bool eventFilter(QObject* watched, QEvent* event);
     bool parseCommandLineArgs();
     DesktopWindow* createDesktopWindow(int screenNum);
     bool autoMountVolume(GVolume* volume, bool interactive = true);

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -29,6 +29,7 @@
 #include <QHash>
 #include <QPoint>
 #include <QByteArray>
+#include <QScreen>
 #include <xcb/xcb.h>
 #include <libfm-qt/core/folder.h>
 
@@ -83,6 +84,8 @@ public:
     }
 
     void setScreenNum(int num);
+
+    QScreen* getDesktopScreen() const;
 
 protected:
     virtual void prepareFolderMenu(Fm::FolderMenu* menu) override;


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/865

`QDesktopWidget` is obsolete and some of its methods don't work correctly. This patch removes it from the code by using `QScreen` methods directly.

As a result, problems with desktop update are also fixed, especially with virtual screens.

P.S. I made the PR because the patch was ready but it could wait until after 0.14.