### PR TITLE
Allow double-clicking an item on the autorun dialog to do that action

### DIFF
--- a/pcmanfm/autorundialog.cpp
+++ b/pcmanfm/autorundialog.cpp
@@ -45,6 +45,8 @@ AutoRunDialog::AutoRunDialog(GVolume* volume, GMount* mount, QWidget* parent, Qt
     ui.listWidget->addItem(item);
 
     g_mount_guess_content_type(mount, TRUE, cancellable, (GAsyncReadyCallback)onContentTypeFinished, this);
+
+    connect(ui.listWidget, &QListWidget::itemDoubleClicked, this, &QDialog::accept);
 }
 
 AutoRunDialog::~AutoRunDialog() {


### PR DESCRIPTION
This trips me up every time I put in a CD and want to open it with the second or third program in the list.