### PR TITLE
Fix crash on sorting by group

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -106,6 +106,7 @@
      <addaction name="actionByFileSize"/>
      <addaction name="actionByFileType"/>
      <addaction name="actionByOwner"/>
+     <addaction name="actionByGroup"/>
      <addaction name="separator"/>
      <addaction name="actionAscending"/>
      <addaction name="actionDescending"/>
@@ -520,6 +521,14 @@
    </property>
    <property name="text">
     <string>By &amp;Owner</string>
+   </property>
+  </action>
+  <action name="actionByGroup">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>By &amp;Group</string>
    </property>
   </action>
   <action name="actionFolderFirst">

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -221,6 +221,7 @@ MainWindow::MainWindow(Fm::FilePath path):
     group->addAction(ui.actionByFileSize);
     group->addAction(ui.actionByFileType);
     group->addAction(ui.actionByOwner);
+    group->addAction(ui.actionByGroup);
 
     group = new QActionGroup(ui.menuSorting);
     group->setExclusive(true);
@@ -848,6 +849,10 @@ void MainWindow::on_actionByOwner_triggered(bool /*checked*/) {
     currentPage()->sort(Fm::FolderModel::ColumnFileOwner, currentPage()->sortOrder());
 }
 
+void MainWindow::on_actionByGroup_triggered(bool /*checked*/) {
+    currentPage()->sort(Fm::FolderModel::ColumnFileGroup, currentPage()->sortOrder());
+}
+
 void MainWindow::on_actionByFileSize_triggered(bool /*checked*/) {
     currentPage()->sort(Fm::FolderModel::ColumnFileSize, currentPage()->sortOrder());
 }
@@ -1191,6 +1196,7 @@ void MainWindow::updateViewMenuForCurrentPage() {
         sortActions[Fm::FolderModel::ColumnFileSize] = ui.actionByFileSize;
         sortActions[Fm::FolderModel::ColumnFileType] = ui.actionByFileType;
         sortActions[Fm::FolderModel::ColumnFileOwner] = ui.actionByOwner;
+        sortActions[Fm::FolderModel::ColumnFileGroup] = ui.actionByGroup;
         sortActions[tabPage->sortColumn()]->setChecked(true);
 
         if(tabPage->sortOrder() == Qt::AscendingOrder) {

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -146,6 +146,7 @@ protected Q_SLOTS:
     void on_actionByFileName_triggered(bool checked);
     void on_actionByMTime_triggered(bool checked);
     void on_actionByOwner_triggered(bool checked);
+    void on_actionByGroup_triggered(bool checked);
     void on_actionByFileType_triggered(bool checked);
     void on_actionByFileSize_triggered(bool checked);
     void on_actionAscending_triggered(bool checked);

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -580,6 +580,9 @@ static const char* sortColumnToString(Fm::FolderModel::ColumnId value) {
     case Fm::FolderModel::ColumnFileOwner:
         ret = "owner";
         break;
+    case Fm::FolderModel::ColumnFileGroup:
+        ret = "group";
+        break;
     }
     return ret;
 }
@@ -600,6 +603,9 @@ static Fm::FolderModel::ColumnId sortColumnFromString(const QString str) {
     }
     else if(str == "owner") {
         ret = Fm::FolderModel::ColumnFileOwner;
+    }
+    else if(str == "group") {
+        ret = Fm::FolderModel::ColumnFileGroup;
     }
     else {
         ret = Fm::FolderModel::ColumnFileName;


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/886

Follows and depends on https://github.com/lxqt/libfm-qt/pull/352

Please note that this fixes a crash but does not fix the inconsistency between View sort menu and that of folder context menu -- that needs another PR after this is (probably) merged.