### PR TITLE
Save/restore custom columns of detailed view

### DIFF
--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -279,6 +279,11 @@ bool Settings::loadFile(QString filePath) {
 
     folderViewCellMargins_ = (settings.value("FolderViewCellMargins", QSize(3, 3)).toSize()
                               .expandedTo(QSize(0, 0))).boundedTo(QSize(48, 48));
+
+    // detailed list columns
+    customColumnWidths_ = settings.value("CustomColumnWidths").toList();
+    hiddenColumns_ = settings.value("HiddenColumns").toList();
+
     settings.endGroup();
 
     settings.beginGroup("Places");
@@ -406,6 +411,12 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue("ThumbnailIconSize", thumbnailIconSize_);
 
     settings.setValue("FolderViewCellMargins", folderViewCellMargins_);
+
+    // detailed list columns
+    settings.setValue("CustomColumnWidths", customColumnWidths_);
+    std::sort(hiddenColumns_.begin(), hiddenColumns_.end());
+    settings.setValue("HiddenColumns", hiddenColumns_);
+
     settings.endGroup();
 
     settings.beginGroup("Places");

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -878,6 +878,36 @@ public:
         searchhHidden_ = hidden;
     }
 
+    QList<int> getCustomColumnWidths() const {
+        QList<int> l;
+        for(auto width : qAsConst(customColumnWidths_)) {
+            l << width.toInt();
+        }
+        return l;
+    }
+
+    void setCustomColumnWidths(const QList<int> &widths) {
+        customColumnWidths_.clear();
+        for(auto width : widths) {
+            customColumnWidths_ << QVariant(width);
+        }
+    }
+
+    QList<int> getHiddenColumns() const {
+        QList<int> l;
+        for(auto width : qAsConst(hiddenColumns_)) {
+            l << width.toInt();
+        }
+        return l;
+    }
+
+    void setHiddenColumns(const QList<int> &columns) {
+        hiddenColumns_.clear();
+        for(auto column : columns) {
+            hiddenColumns_ << QVariant(column);
+        }
+    }
+
 private:
     int toIconSize(int size, IconType type) const;
 
@@ -984,6 +1014,10 @@ private:
     bool searchContentRegexp_;
     bool searchRecursive_;
     bool searchhHidden_;
+
+    // detailed list columns
+    QList<QVariant> customColumnWidths_;
+    QList<QVariant> hiddenColumns_;
 };
 
 }

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -130,6 +130,16 @@ TabPage::TabPage(QWidget* parent):
     connect(folderView_, &View::clickedBack, this, &TabPage::backwardRequested);
     connect(folderView_, &View::clickedForward, this, &TabPage::forwardRequested);
 
+    // customization of columns of detailed list view
+    folderView_->setCustomColumnWidths(settings.getCustomColumnWidths());
+    folderView_->setHiddenColumns(settings.getHiddenColumns());
+    connect(folderView_, &View::columnResizedByUser, this, [this, &settings]() {
+        settings.setCustomColumnWidths(folderView_->getCustomColumnWidths());
+    });
+    connect(folderView_, &View::columnHiddenByUser, this, [this, &settings]() {
+        settings.setHiddenColumns(folderView_->getHiddenColumns());
+    });
+
     proxyFilter_ = new ProxyFilter();
     proxyModel_->addFilter(proxyFilter_);
 


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/623

Follows and depends on https://github.com/lxqt/libfm-qt/pull/355

The user can start customizing columns of the detailed list view by right clicking on its header. Then, the changes will be remembered for next opened views and will be saved to disk on quitting (like other settings) for the next session.

The last customization takes priority over the previous ones.

NOTE: The previous patches about fixing file group should be applied before this.