### PR TITLE
Fixed status message on changing view from/to detailed list

### DIFF
--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -729,11 +729,14 @@ void TabPage::setViewMode(Fm::FolderView::ViewMode mode) {
     Fm::FolderView::ViewMode prevMode = folderView_->viewMode();
     folderView_->setViewMode(mode);
     folderView_->childView()->setFocus();
-    if(!settings.showFilter() && prevMode != folderView_->viewMode()) {
+    if(prevMode != folderView_->viewMode()) {
         // FolderView::setViewMode() may delete the view to switch between list and tree.
-        // So, the event filter should be re-installed.
-        folderView_->childView()->removeEventFilter(this);
-        folderView_->childView()->installEventFilter(this);
+        // So, the event filter should be re-installed and the status message should be updated.
+        if(!settings.showFilter()) {
+            folderView_->childView()->removeEventFilter(this);
+            folderView_->childView()->installEventFilter(this);
+        }
+        onSelChanged();
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/890

The view is recreated when going to/from the detailed list; so the status message should be updated.