### PR TITLE
Corrected the logic of sorting

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -832,9 +832,6 @@ void MainWindow::on_actionFolderProperties_triggered() {
 void MainWindow::on_actionShowHidden_triggered(bool checked) {
     currentPage()->setShowHidden(checked);
     ui.sidePane->setShowHidden(checked);
-    if(!currentPage()->hasCustomizedView()) {
-        static_cast<Application*>(qApp)->settings().setShowHidden(checked);  // remember globally
-    }
 }
 
 void MainWindow::on_actionByFileName_triggered(bool /*checked*/) {
@@ -1414,19 +1411,18 @@ void MainWindow::onTabPageOpenDirRequested(const Fm::FilePath& path, int target)
     }
 }
 
-void MainWindow::onTabPageSortFilterChanged() {
+void MainWindow::onTabPageSortFilterChanged() { // NOTE: This may be called from context menu too.
     TabPage* tabPage = static_cast<TabPage*>(sender());
     if(tabPage == currentPage()) {
         updateViewMenuForCurrentPage();
-        if(!tabPage->hasCustomizedView()) {
+        if(!tabPage->hasCustomizedView()) { // remember sort settings globally
             Settings& settings = static_cast<Application*>(qApp)->settings();
             settings.setSortColumn(static_cast<Fm::FolderModel::ColumnId>(tabPage->sortColumn()));
             settings.setSortOrder(tabPage->sortOrder());
             settings.setSortFolderFirst(tabPage->sortFolderFirst());
             settings.setSortCaseSensitive(tabPage->sortCaseSensitive());
-            settings.setShowHidden(tabPage->showHidden()); // remember globally , as in on_actionShowHidden_triggered()
+            settings.setShowHidden(tabPage->showHidden());
         }
-        tabPage->setShowHidden(tabPage->showHidden()); // change status text and perfolder setting
     }
 }
 

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -116,7 +116,10 @@ TabPage::TabPage(QWidget* parent):
     proxyModel_->setShowHidden(settings.showHidden());
     proxyModel_->setBackupAsHidden(settings.backupAsHidden());
     proxyModel_->setShowThumbnails(settings.showThumbnails());
-    connect(proxyModel_, &ProxyFolderModel::sortFilterChanged, this, &TabPage::sortFilterChanged);
+    connect(proxyModel_, &ProxyFolderModel::sortFilterChanged, this, [this] {
+        saveFolderSorting();
+        Q_EMIT sortFilterChanged();
+    });
 
     verticalLayout = new QVBoxLayout(this);
     verticalLayout->setContentsMargins(0, 0, 0, 0);
@@ -553,15 +556,19 @@ void TabPage::chdir(Fm::FilePath newPath, bool addHistory) {
     folderModel_ = CachedFolderModel::modelFromFolder(folder_);
     folderModel_->setShowFullName(settings.showFullNames());
 
-    // set sorting, considering customized folders
-    folderSettings_ = settings.loadFolderSettings(path());
-    proxyModel_->sort(folderSettings_.sortColumn(), folderSettings_.sortOrder());
-    proxyModel_->setFolderFirst(folderSettings_.sortFolderFirst());
-    proxyModel_->setShowHidden(folderSettings_.showHidden());
-    proxyModel_->setSortCaseSensitivity(folderSettings_.sortCaseSensitive() ? Qt::CaseSensitive : Qt::CaseInsensitive);
-    proxyModel_->setSourceModel(folderModel_);
+    // folderSettings_ will be set by saveFolderSorting() when the sort filter is changed below
+    // (and also by setViewMode()); here, we only need to know whether it should be saved
+    FolderSettings folderSettings = settings.loadFolderSettings(path());
+    folderSettings_.setCustomized(folderSettings.isCustomized());
 
-    setViewMode(folderSettings_.viewMode());
+    // set sorting
+    proxyModel_->sort(folderSettings.sortColumn(), folderSettings.sortOrder());
+    proxyModel_->setFolderFirst(folderSettings.sortFolderFirst());
+    proxyModel_->setShowHidden(folderSettings.showHidden());
+    proxyModel_->setSortCaseSensitivity(folderSettings.sortCaseSensitive() ? Qt::CaseSensitive : Qt::CaseInsensitive);
+    proxyModel_->setSourceModel(folderModel_);
+    // set view mode
+    setViewMode(folderSettings.viewMode());
 
     if(folder_->isLoaded()) {
         onFolderStartLoading();
@@ -751,59 +758,49 @@ void TabPage::setViewMode(Fm::FolderView::ViewMode mode) {
 }
 
 void TabPage::sort(int col, Qt::SortOrder order) {
-    if(folderSettings_.sortColumn() != col || folderSettings_.sortOrder() != order) {
-        folderSettings_.setSortColumn(Fm::FolderModel::ColumnId(col));
-        folderSettings_.setSortOrder(order);
-        if(folderSettings_.isCustomized()) {
-            static_cast<Application*>(qApp)->settings().saveFolderSettings(path(), folderSettings_);
-        }
-    }
     if(proxyModel_) {
         proxyModel_->sort(col, order);
     }
 }
 
 void TabPage::setSortFolderFirst(bool value) {
-    if(folderSettings_.sortFolderFirst() != value) {
-        folderSettings_.setSortFolderFirst(value);
-        if(folderSettings_.isCustomized()) {
-            static_cast<Application*>(qApp)->settings().saveFolderSettings(path(), folderSettings_);
-        }
+    if(proxyModel_) {
+        proxyModel_->setFolderFirst(value);
     }
-    proxyModel_->setFolderFirst(value);
 }
 
 void TabPage::setSortCaseSensitive(bool value) {
-    if(folderSettings_.sortCaseSensitive() != value) {
-        folderSettings_.setSortCaseSensitive(value);
-        if(folderSettings_.isCustomized()) {
-            static_cast<Application*>(qApp)->settings().saveFolderSettings(path(), folderSettings_);
-        }
+    if(proxyModel_) {
+        proxyModel_->setSortCaseSensitivity(value ? Qt::CaseSensitive : Qt::CaseInsensitive);
     }
-    proxyModel_->setSortCaseSensitivity(value ? Qt::CaseSensitive : Qt::CaseInsensitive);
 }
 
-
 void TabPage::setShowHidden(bool showHidden) {
-    if(folderSettings_.showHidden() != showHidden) {
-        folderSettings_.setShowHidden(showHidden);
-        if(folderSettings_.isCustomized()) {
-            static_cast<Application*>(qApp)->settings().saveFolderSettings(path(), folderSettings_);
-        }
-    }
-    if(!proxyModel_) {
-        return;
-    }
-    if(showHidden != proxyModel_->showHidden()) {
+    if(proxyModel_) {
         proxyModel_->setShowHidden(showHidden);
     }
-    // this may also be called by MainWindow::onTabPageSortFilterChanged to set status message
-    statusText_[StatusTextNormal] = formatStatusText();
-    Q_EMIT statusChanged(StatusTextNormal, statusText_[StatusTextNormal]);
+}
+
+void TabPage::saveFolderSorting() {
+    if (proxyModel_ == nullptr) {
+        return;
+    }
+    folderSettings_.setSortOrder(proxyModel_->sortOrder());
+    folderSettings_.setSortColumn(static_cast<Fm::FolderModel::ColumnId>(proxyModel_->sortColumn()));
+    folderSettings_.setSortFolderFirst(proxyModel_->folderFirst());
+    folderSettings_.setSortCaseSensitive(proxyModel_->sortCaseSensitivity());
+    if(folderSettings_.showHidden() != proxyModel_->showHidden()) {
+        folderSettings_.setShowHidden(proxyModel_->showHidden());
+        statusText_[StatusTextNormal] = formatStatusText();
+        Q_EMIT statusChanged(StatusTextNormal, statusText_[StatusTextNormal]);
+    }
+    if(folderSettings_.isCustomized()) {
+        static_cast<Application*>(qApp)->settings().saveFolderSettings(path(), folderSettings_);
+    }
 }
 
 void TabPage::applyFilter() {
-    if(!proxyModel_) {
+    if(proxyModel_ == nullptr) {
         return;
     }
     int prevSelSize = folderView_->selectionModel()->selectedIndexes().size();

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -154,6 +154,8 @@ public:
 
     void setShowHidden(bool showHidden);
 
+    void saveFolderSorting();
+
     Fm::FilePath path() {
         return folder_ ? folder_->path() : Fm::FilePath();
     }


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/887

When a tab page's sorting is changed in whatever way, remember it.

In this way, there will be no difference between changing the sorting (or showing hidden files) from the context menu and from the menu-bar. Also, because of the sane logic, all hassles related to showing hidden files should be eliminated.