### PR TITLE
Tell users about dbus-launch

### DIFF
--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -704,11 +704,13 @@ only if there are more than one tab.</string>
             <item row="2" column="0" colspan="2">
              <widget class="QLabel" name="label_4">
               <property name="text">
-               <string>Examples: &quot;xterm -e %s&quot; for terminal or &quot;gksu %s&quot; for switching user.
-%s = the command line you want to execute with terminal or su.</string>
+               <string>Examples:&lt;br&gt;For terminal: &lt;i&gt;xterm -e %s&lt;/i&gt;&lt;br&gt;For switching user: &lt;i&gt;lxsudo %s&lt;/i&gt; or &lt;i&gt;lxsudo dbus-launch %s&lt;/i&gt;&lt;br&gt;&lt;i&gt;%s&lt;/i&gt; is the command line you want to execute with terminal or su.</string>
               </property>
               <property name="textFormat">
-               <enum>Qt::PlainText</enum>
+               <enum>Qt::RichText</enum>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Because it may be needed for launching a root instance.

Also, use rich text to prevent confusion about quotation marks.