### PR TITLE
WIP: Option to enable passing mousewheel to root window

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -513,9 +513,9 @@ A space is also reserved for 3 lines of text.</string>
          </property>
          <layout class="QVBoxLayout" name="horizontalLayout_3">
           <item>
-           <widget class="QCheckBox" name="passButtonsToRoot">
+           <widget class="QCheckBox" name="showWmMenu">
             <property name="text">
-             <string>Pass clicks on the desktop to the window manager.</string>
+             <string>Show menus provided by window managers when desktop is clicked.</string>
             </property>
            </widget>
           </item>

--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -511,11 +511,18 @@ A space is also reserved for 3 lines of text.</string>
          <property name="title">
           <string>Window Manager</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <layout class="QVBoxLayout" name="horizontalLayout_3">
           <item>
-           <widget class="QCheckBox" name="showWmMenu">
+           <widget class="QCheckBox" name="passButtonsToRoot">
             <property name="text">
-             <string>Show menus provided by window managers when desktop is clicked</string>
+             <string>Pass clicks on the desktop to the window manager.</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="passWheelToRoot">
+            <property name="text">
+             <string>Pass scroll wheel actions on the desktop to the window manager.</string>
             </property>
            </widget>
           </item>

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -111,7 +111,7 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
   ui.computerBox->setChecked(ds.contains(QLatin1String("Computer")));
   ui.networkBox->setChecked(ds.contains(QLatin1String("Network")));
 
-  ui.passButtonsToRoot->setChecked(settings.passButtonsToRoot());
+  ui.showWmMenu->setChecked(settings.showWmMenu());
   ui.passWheelToRoot->setChecked(settings.passWheelToRoot());
 
   connect(ui.buttonBox->button(QDialogButtonBox::Apply), &QPushButton::clicked,
@@ -191,7 +191,7 @@ void DesktopPreferencesDialog::applySettings()
   }
   settings.setDesktopShortcuts(ds);
 
-  settings.setPassButtonsToRoot(ui.passButtonsToRoot->isChecked());
+  settings.setShowWmMenu(ui.showWmMenu->isChecked());
   settings.setPassWheelToRoot(ui.passWheelToRoot->isChecked());
 
   settings.setDesktopCellMargins(QSize(ui.hMargin->value(), ui.vMargin->value()));

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -111,7 +111,8 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
   ui.computerBox->setChecked(ds.contains(QLatin1String("Computer")));
   ui.networkBox->setChecked(ds.contains(QLatin1String("Network")));
 
-  ui.showWmMenu->setChecked(settings.showWmMenu());
+  ui.passButtonsToRoot->setChecked(settings.passButtonsToRoot());
+  ui.passWheelToRoot->setChecked(settings.passWheelToRoot());
 
   connect(ui.buttonBox->button(QDialogButtonBox::Apply), &QPushButton::clicked,
           this, &DesktopPreferencesDialog::onApplyClicked);
@@ -190,7 +191,8 @@ void DesktopPreferencesDialog::applySettings()
   }
   settings.setDesktopShortcuts(ds);
 
-  settings.setShowWmMenu(ui.showWmMenu->isChecked());
+  settings.setPassButtonsToRoot(ui.passButtonsToRoot->isChecked());
+  settings.setPassWheelToRoot(ui.passWheelToRoot->isChecked());
 
   settings.setDesktopCellMargins(QSize(ui.hMargin->value(), ui.vMargin->value()));
 

--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -742,7 +742,7 @@ void DesktopWindow::updateFromSettings(Settings& settings, bool changeSlide) {
     setForeground(settings.desktopFgColor());
     setBackground(settings.desktopBgColor());
     setShadow(settings.desktopShadowColor());
-    showWmMenu_ = settings.passButtonsToRoot();
+    showWmMenu_ = settings.showWmMenu();
     passWheelToRoot_ = settings.passWheelToRoot();
     desktopHideItems_ = settings.desktopHideItems();
     if(desktopHideItems_) {
@@ -1591,10 +1591,8 @@ bool DesktopWindow::eventFilter(QObject* watched, QEvent* event) {
                 QModelIndex index = listView_->indexAt(e->pos());
                 if(!index.isValid()) {
                     forwardWheelEventToRoot(e);
-                    return true;
                 }
             }
-            break;
             return true;
         default:
             break;

--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -58,7 +58,6 @@
 #include <QX11Info>
 #include <QScreen>
 #include <xcb/xcb.h>
-#include <xcb/xinput.h>
 #include <X11/Xlib.h>
 
 #define WORK_AREA_MARGIN 12 // margin of the work area

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -175,7 +175,8 @@ private:
     bool wallpaperRandomize_;
     QPixmap wallpaperPixmap_;
     Launcher fileLauncher_;
-    bool showWmMenu_;
+    bool passButtonsToRoot_;
+    bool passWheelToRoot_;
     bool desktopHideItems_;
 
     int screenNum_;

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -175,7 +175,7 @@ private:
     bool wallpaperRandomize_;
     QPixmap wallpaperPixmap_;
     Launcher fileLauncher_;
-    bool passButtonsToRoot_;
+    bool showWmMenu_;
     bool passWheelToRoot_;
     bool desktopHideItems_;
 

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -72,7 +72,8 @@ Settings::Settings():
     desktopFgColor_(),
     desktopShadowColor_(),
     desktopIconSize_(48),
-    showWmMenu_(false),
+    passButtonsToRoot_(false),
+    passWheelToRoot_(false),
     desktopShowHidden_(false),
     desktopHideItems_(false),
     desktopSortOrder_(Qt::AscendingOrder),
@@ -233,7 +234,8 @@ bool Settings::loadFile(QString filePath) {
     }
     desktopIconSize_ = settings.value("DesktopIconSize", 48).toInt();
     desktopShortcuts_ = settings.value("DesktopShortcuts").toStringList();
-    showWmMenu_ = settings.value("ShowWmMenu", false).toBool();
+    passButtonsToRoot_ = settings.value("passButtonsToRoot", false).toBool();
+    passWheelToRoot_ = settings.value("passWheelToRoot", false).toBool();
     desktopShowHidden_ = settings.value("ShowHidden", false).toBool();
     desktopHideItems_ = settings.value("HideItems", false).toBool();
 
@@ -369,7 +371,8 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue("Font", desktopFont_.toString());
     settings.setValue("DesktopIconSize", desktopIconSize_);
     settings.setValue("DesktopShortcuts", desktopShortcuts_);
-    settings.setValue("ShowWmMenu", showWmMenu_);
+    settings.setValue("passButtonsToRoot", passButtonsToRoot_);
+    settings.setValue("passWheelToRoot", passWheelToRoot_);
     settings.setValue("ShowHidden", desktopShowHidden_);
     settings.setValue("HideItems", desktopHideItems_);
     settings.setValue("SortOrder", sortOrderToString(desktopSortOrder_));

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -72,7 +72,7 @@ Settings::Settings():
     desktopFgColor_(),
     desktopShadowColor_(),
     desktopIconSize_(48),
-    passButtonsToRoot_(false),
+    showWmMenu_(false),
     passWheelToRoot_(false),
     desktopShowHidden_(false),
     desktopHideItems_(false),
@@ -234,8 +234,8 @@ bool Settings::loadFile(QString filePath) {
     }
     desktopIconSize_ = settings.value("DesktopIconSize", 48).toInt();
     desktopShortcuts_ = settings.value("DesktopShortcuts").toStringList();
-    passButtonsToRoot_ = settings.value("passButtonsToRoot", false).toBool();
-    passWheelToRoot_ = settings.value("passWheelToRoot", false).toBool();
+    showWmMenu_ = settings.value("ShowWmMenu", false).toBool();
+    passWheelToRoot_ = settings.value("PassWheelToRoot", false).toBool();
     desktopShowHidden_ = settings.value("ShowHidden", false).toBool();
     desktopHideItems_ = settings.value("HideItems", false).toBool();
 
@@ -371,8 +371,8 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue("Font", desktopFont_.toString());
     settings.setValue("DesktopIconSize", desktopIconSize_);
     settings.setValue("DesktopShortcuts", desktopShortcuts_);
-    settings.setValue("passButtonsToRoot", passButtonsToRoot_);
-    settings.setValue("passWheelToRoot", passWheelToRoot_);
+    settings.setValue("ShowWmMenu", showWmMenu_);
+    settings.setValue("PassWheelToRoot", passWheelToRoot_);
     settings.setValue("ShowHidden", desktopShowHidden_);
     settings.setValue("HideItems", desktopHideItems_);
     settings.setValue("SortOrder", sortOrderToString(desktopSortOrder_));

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -321,12 +321,12 @@ public:
         desktopShortcuts_ = list;
     }
 
-    bool passButtonsToRoot() const {
-        return passButtonsToRoot_;
+    bool showWmMenu() const {
+        return showWmMenu_;
     }
     
-    void setPassButtonsToRoot(bool value) {
-        passButtonsToRoot_ = value;
+    void setShowWmMenu(bool value) {
+        showWmMenu_ = value;
     }
     
     bool passWheelToRoot() const {
@@ -946,7 +946,7 @@ private:
     QFont desktopFont_;
     int desktopIconSize_;
     QStringList desktopShortcuts_;
-    bool passButtonsToRoot_;
+    bool showWmMenu_;
     bool passWheelToRoot_;
 
     bool desktopShowHidden_;

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -321,14 +321,22 @@ public:
         desktopShortcuts_ = list;
     }
 
-    bool showWmMenu() const {
-        return showWmMenu_;
+    bool passButtonsToRoot() const {
+        return passButtonsToRoot_;
+    }
+    
+    void setPassButtonsToRoot(bool value) {
+        passButtonsToRoot_ = value;
+    }
+    
+    bool passWheelToRoot() const {
+        return passWheelToRoot_;
     }
 
-    void setShowWmMenu(bool value) {
-        showWmMenu_ = value;
+    void setPassWheelToRoot(bool value) {
+        passWheelToRoot_ = value;
     }
-
+    
     bool desktopShowHidden() const {
         return desktopShowHidden_;
     }
@@ -938,7 +946,8 @@ private:
     QFont desktopFont_;
     int desktopIconSize_;
     QStringList desktopShortcuts_;
-    bool showWmMenu_;
+    bool passButtonsToRoot_;
+    bool passWheelToRoot_;
 
     bool desktopShowHidden_;
     bool desktopHideItems_;


### PR DESCRIPTION
Enables to not only pass middle and left click to the window manager for menus, but also to pass mouse wheel action (vertically and horizontally), to e.g. allow desktop switching.

Can be enabled/disabled via a separate checkbox in the settings window.
