### PR TITLE
Removed WM menu from desktop

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -507,22 +507,6 @@ A space is also reserved for 3 lines of text.</string>
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_4">
-         <property name="title">
-          <string>Window Manager</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <widget class="QCheckBox" name="showWmMenu">
-            <property name="text">
-             <string>Show menus provided by window managers when desktop is clicked</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -111,8 +111,6 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
   ui.computerBox->setChecked(ds.contains(QLatin1String("Computer")));
   ui.networkBox->setChecked(ds.contains(QLatin1String("Network")));
 
-  ui.showWmMenu->setChecked(settings.showWmMenu());
-
   connect(ui.buttonBox->button(QDialogButtonBox::Apply), &QPushButton::clicked,
           this, &DesktopPreferencesDialog::onApplyClicked);
 
@@ -189,8 +187,6 @@ void DesktopPreferencesDialog::applySettings()
       ds << QLatin1String("Network");
   }
   settings.setDesktopShortcuts(ds);
-
-  settings.setShowWmMenu(ui.showWmMenu->isChecked());
 
   settings.setDesktopCellMargins(QSize(ui.hMargin->value(), ui.vMargin->value()));
 

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -175,7 +175,6 @@ private:
     bool wallpaperRandomize_;
     QPixmap wallpaperPixmap_;
     Launcher fileLauncher_;
-    bool showWmMenu_;
     bool desktopHideItems_;
 
     int screenNum_;

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -72,7 +72,6 @@ Settings::Settings():
     desktopFgColor_(),
     desktopShadowColor_(),
     desktopIconSize_(48),
-    showWmMenu_(false),
     desktopShowHidden_(false),
     desktopHideItems_(false),
     desktopSortOrder_(Qt::AscendingOrder),
@@ -233,7 +232,6 @@ bool Settings::loadFile(QString filePath) {
     }
     desktopIconSize_ = settings.value("DesktopIconSize", 48).toInt();
     desktopShortcuts_ = settings.value("DesktopShortcuts").toStringList();
-    showWmMenu_ = settings.value("ShowWmMenu", false).toBool();
     desktopShowHidden_ = settings.value("ShowHidden", false).toBool();
     desktopHideItems_ = settings.value("HideItems", false).toBool();
 
@@ -369,7 +367,6 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue("Font", desktopFont_.toString());
     settings.setValue("DesktopIconSize", desktopIconSize_);
     settings.setValue("DesktopShortcuts", desktopShortcuts_);
-    settings.setValue("ShowWmMenu", showWmMenu_);
     settings.setValue("ShowHidden", desktopShowHidden_);
     settings.setValue("HideItems", desktopHideItems_);
     settings.setValue("SortOrder", sortOrderToString(desktopSortOrder_));

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -321,14 +321,6 @@ public:
         desktopShortcuts_ = list;
     }
 
-    bool showWmMenu() const {
-        return showWmMenu_;
-    }
-
-    void setShowWmMenu(bool value) {
-        showWmMenu_ = value;
-    }
-
     bool desktopShowHidden() const {
         return desktopShowHidden_;
     }
@@ -938,7 +930,6 @@ private:
     QFont desktopFont_;
     int desktopIconSize_;
     QStringList desktopShortcuts_;
-    bool showWmMenu_;
 
     bool desktopShowHidden_;
     bool desktopHideItems_;


### PR DESCRIPTION
Because:
(1) Only some X11 WMs have desktop context menus, while LXQt is WM-agnostic;
(2) It hid our FM desktop context menu; and
(3) X11 codes should be kept only when really useful because they are an obstacle to preparing for Wayland.

NOTE: "Advanced" is preserved for the tab name because an extra item is added to it outside LXQt.

Closes https://github.com/lxqt/pcmanfm-qt/issues/931