### PR TITLE
Changed thumbnail view icon to view-preview

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -201,7 +201,7 @@ MainWindow::MainWindow(Fm::FilePath path):
 
     // use generic icons for view actions only if theme icons don't exist
     ui.actionIconView->setIcon(QIcon::fromTheme(QLatin1String("view-list-icons"), style()->standardIcon(QStyle::SP_FileDialogContentsView)));
-    ui.actionThumbnailView->setIcon(QIcon::fromTheme(QLatin1String("dialog-information"), style()->standardIcon(QStyle::SP_FileDialogInfoView)));
+    ui.actionThumbnailView->setIcon(QIcon::fromTheme(QLatin1String("view-preview"), style()->standardIcon(QStyle::SP_FileDialogInfoView)));
     ui.actionCompactView->setIcon(QIcon::fromTheme(QLatin1String("view-list-text"), style()->standardIcon(QStyle::SP_FileDialogListView)));
     ui.actionDetailedList->setIcon(QIcon::fromTheme(QLatin1String("view-list-details"), style()->standardIcon(QStyle::SP_FileDialogDetailedView)));
 


### PR DESCRIPTION
"dialog-information" wasn't a good choice but the reason behind it was understandable (Qt doesn't have an internal icon for it).

Closes https://github.com/lxqt/pcmanfm-qt/issues/771