### PR TITLE
Prevent future crash if a new sort column is added in libfm-qt

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -1185,14 +1185,31 @@ void MainWindow::updateViewMenuForCurrentPage() {
         modeAction->setChecked(true);
 
         // sort menu
+        // WARNING: Since libfm-qt may have a column that is not handled here,
+        // we should prevent a crash by setting all actions to null first and
+        // check their action group later.
         QAction* sortActions[Fm::FolderModel::NumOfColumns];
+        for(int i = 0; i < Fm::FolderModel::NumOfColumns; ++i) {
+            sortActions[i] = nullptr;
+        }
         sortActions[Fm::FolderModel::ColumnFileName] = ui.actionByFileName;
         sortActions[Fm::FolderModel::ColumnFileMTime] = ui.actionByMTime;
         sortActions[Fm::FolderModel::ColumnFileSize] = ui.actionByFileSize;
         sortActions[Fm::FolderModel::ColumnFileType] = ui.actionByFileType;
         sortActions[Fm::FolderModel::ColumnFileOwner] = ui.actionByOwner;
         sortActions[Fm::FolderModel::ColumnFileGroup] = ui.actionByGroup;
-        sortActions[tabPage->sortColumn()]->setChecked(true);
+        if (auto group = ui.actionByFileName->actionGroup()) {
+            const auto actions = group->actions();
+            auto action = sortActions[tabPage->sortColumn()];
+            if(actions.contains(action)) {
+                action->setChecked(true);
+            }
+            else {
+                for(auto a : actions) {
+                    a->setChecked(false);
+                }
+            }
+        }
 
         if(tabPage->sortOrder() == Qt::AscendingOrder) {
             ui.actionAscending->setChecked(true);


### PR DESCRIPTION
If a new sort column is added to detailed list view in libfm-qt but there's no corresponding action in pcmanfm-qt's sort menu, pcmanfm-qt will crash. This patch prevents that.

Such a scenario is possible in 2 ways:

(1) The change may have been made to libfm-qt but not yet to pcmanfm-qt.
(2) Although not likely, we might really not want to add an action corresponding to a new sort column.

Anyways, pcmanfm-qt shouldn't crash.