### PR TITLE
Add Escape as a shortcut to dismiss filter

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -261,7 +261,12 @@ MainWindow::MainWindow(Fm::FilePath path):
     // create shortcuts
     QShortcut* shortcut;
     shortcut = new QShortcut(QKeySequence(Qt::Key_Escape), this);
-    connect(shortcut, &QShortcut::activated, this, &MainWindow::onResetFocus);
+    connect(shortcut, &QShortcut::activated, [this] {
+        if(currentPage()) {
+            currentPage()->clearFilter();
+            currentPage()->folderView()->childView()->setFocus();
+        }
+    });
 
     shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_L), this);
     connect(shortcut, &QShortcut::activated, this, &MainWindow::focusPathEntry);

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -59,7 +59,7 @@ bool ProxyFilter::filterAcceptsRow(const Fm::ProxyFolderModel* model, const std:
 FilterEdit::FilterEdit(QWidget* parent) : QLineEdit(parent) {
     setClearButtonEnabled(true);
     if(QToolButton *clearButton = findChild<QToolButton*>()) {
-        clearButton->setToolTip(tr("Clear text (Ctrl+K)"));
+        clearButton->setToolTip(tr("Clear text (Ctrl+K or Esc)"));
     }
 }
 


### PR DESCRIPTION
Add Escape as a shortcut to dismiss filter, subject to discussion in #945.