### PR TITLE
Enhanced wallpaper browsing dialog

### DIFF
--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -64,6 +64,8 @@ Settings::Settings():
     closeOnUnmount_(false),
     wallpaperMode_(0),
     wallpaper_(),
+    wallpaperDialogSize_(QSize(700, 500)),
+    wallpaperDialogSplitterPos_(200),
     lastSlide_(),
     wallpaperDir_(),
     slideShowInterval_(0),
@@ -217,6 +219,8 @@ bool Settings::loadFile(QString filePath) {
     settings.beginGroup("Desktop");
     wallpaperMode_ = wallpaperModeFromString(settings.value("WallpaperMode").toString());
     wallpaper_ = settings.value("Wallpaper").toString();
+    wallpaperDialogSize_ = settings.value("WallpaperDialogSize", QSize(700, 500)).toSize();
+    wallpaperDialogSplitterPos_ = settings.value("WallpaperDialogSplitterPos", 200).toInt();
     lastSlide_ = settings.value("LastSlide").toString();
     wallpaperDir_ = settings.value("WallpaperDirectory").toString();
     slideShowInterval_ = settings.value("SlideShowInterval", 0).toInt();
@@ -357,6 +361,8 @@ bool Settings::saveFile(QString filePath) {
     settings.beginGroup("Desktop");
     settings.setValue("WallpaperMode", wallpaperModeToString(wallpaperMode_));
     settings.setValue("Wallpaper", wallpaper_);
+    settings.setValue("WallpaperDialogSize", wallpaperDialogSize_);
+    settings.setValue("WallpaperDialogSplitterPos", wallpaperDialogSplitterPos_);
     settings.setValue("LastSlide", lastSlide_);
     settings.setValue("WallpaperDirectory", wallpaperDir_);
     settings.setValue("SlideShowInterval", slideShowInterval_);

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -241,6 +241,22 @@ public:
         wallpaper_ = wallpaper;
     }
 
+    QSize wallpaperDialogSize() const {
+        return wallpaperDialogSize_;
+    }
+
+    void setWallpaperDialogSize(const QSize& size) {
+        wallpaperDialogSize_ = size;
+    }
+
+    int wallpaperDialogSplitterPos() const {
+        return wallpaperDialogSplitterPos_;
+    }
+
+    void setWallpaperDialogSplitterPos(int pos) {
+        wallpaperDialogSplitterPos_ = pos;
+    }
+
     QString wallpaperDir() const {
         return wallpaperDir_;
     }
@@ -920,6 +936,8 @@ private:
 
     int wallpaperMode_;
     QString wallpaper_;
+    QSize wallpaperDialogSize_;
+    int wallpaperDialogSplitterPos_;
     QString lastSlide_;
     QString wallpaperDir_;
     int slideShowInterval_;


### PR DESCRIPTION
Use LXQt file dialog directly, set it to thumbnail view mode, select and scroll to the current wallpaper in it, and remember its size and splitter position.

The slide-show dialog is still the default LXQt file dialog because it only shows folders.

Closes https://github.com/lxqt/lxqt/issues/391