### PR TITLE
Added deletion time to Trash

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -103,6 +103,7 @@
      </property>
      <addaction name="actionByFileName"/>
      <addaction name="actionByMTime"/>
+     <addaction name="actionByDTime"/>
      <addaction name="actionByFileSize"/>
      <addaction name="actionByFileType"/>
      <addaction name="actionByOwner"/>
@@ -505,6 +506,14 @@
    </property>
    <property name="text">
     <string>By &amp;Modification Time</string>
+   </property>
+  </action>
+  <action name="actionByDTime">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>By Deletio&amp;n Time</string>
    </property>
   </action>
   <action name="actionByFileType">

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -216,6 +216,7 @@ MainWindow::MainWindow(Fm::FilePath path):
     group->setExclusive(true);
     group->addAction(ui.actionByFileName);
     group->addAction(ui.actionByMTime);
+    group->addAction(ui.actionByDTime);
     group->addAction(ui.actionByFileSize);
     group->addAction(ui.actionByFileType);
     group->addAction(ui.actionByOwner);
@@ -845,6 +846,10 @@ void MainWindow::on_actionByMTime_triggered(bool /*checked*/) {
     currentPage()->sort(Fm::FolderModel::ColumnFileMTime, currentPage()->sortOrder());
 }
 
+void MainWindow::on_actionByDTime_triggered(bool /*checked*/) {
+    currentPage()->sort(Fm::FolderModel::ColumnFileDTime, currentPage()->sortOrder());
+}
+
 void MainWindow::on_actionByOwner_triggered(bool /*checked*/) {
     currentPage()->sort(Fm::FolderModel::ColumnFileOwner, currentPage()->sortOrder());
 }
@@ -1199,6 +1204,7 @@ void MainWindow::updateViewMenuForCurrentPage() {
         }
         sortActions[Fm::FolderModel::ColumnFileName] = ui.actionByFileName;
         sortActions[Fm::FolderModel::ColumnFileMTime] = ui.actionByMTime;
+        sortActions[Fm::FolderModel::ColumnFileDTime] = ui.actionByDTime;
         sortActions[Fm::FolderModel::ColumnFileSize] = ui.actionByFileSize;
         sortActions[Fm::FolderModel::ColumnFileType] = ui.actionByFileType;
         sortActions[Fm::FolderModel::ColumnFileOwner] = ui.actionByOwner;
@@ -1214,6 +1220,10 @@ void MainWindow::updateViewMenuForCurrentPage() {
                     a->setChecked(false);
                 }
             }
+        }
+
+        if(auto path = tabPage->path()) {
+            ui.actionByDTime->setVisible(strcmp(path.toString().get(), "trash:///") == 0);
         }
 
         if(tabPage->sortOrder() == Qt::AscendingOrder) {

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -145,6 +145,7 @@ protected Q_SLOTS:
 
     void on_actionByFileName_triggered(bool checked);
     void on_actionByMTime_triggered(bool checked);
+    void on_actionByDTime_triggered(bool checked);
     void on_actionByOwner_triggered(bool checked);
     void on_actionByGroup_triggered(bool checked);
     void on_actionByFileType_triggered(bool checked);

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -591,6 +591,9 @@ static const char* sortColumnToString(Fm::FolderModel::ColumnId value) {
     case Fm::FolderModel::ColumnFileMTime:
         ret = "mtime";
         break;
+    case Fm::FolderModel::ColumnFileDTime:
+        ret = "dtime";
+        break;
     case Fm::FolderModel::ColumnFileOwner:
         ret = "owner";
         break;
@@ -614,6 +617,9 @@ static Fm::FolderModel::ColumnId sortColumnFromString(const QString str) {
     }
     else if(str == QLatin1String("mtime")) {
         ret = Fm::FolderModel::ColumnFileMTime;
+    }
+    else if(str == QLatin1String("dtime")) {
+        ret = Fm::FolderModel::ColumnFileDTime;
     }
     else if(str == QLatin1String("owner")) {
         ret = Fm::FolderModel::ColumnFileOwner;


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/367

This follows and depends on https://github.com/lxqt/libfm-qt/pull/428. It completes sorting by deletion time in pcmanfm-qt, so that the user could customize Trash and sort its item by deleton time, independently from other folders.

NOTE: Detailed list column customization might need to be repeated after this.