### PR TITLE
Added option to transform jpeg wallpapers based on EXIF info

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -66,7 +66,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="6" column="1">
            <widget class="Fm::ColorButton" name="backgroundColor">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -79,7 +79,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="label_5">
             <property name="text">
              <string>Select background color:</string>
@@ -109,6 +109,13 @@
              </widget>
             </item>
            </layout>
+          </item>
+          <item row="5" column="0" colspan="3">
+           <widget class="QCheckBox" name="transformImage">
+            <property name="text">
+             <string>Transform image based on EXIF data</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -84,6 +84,7 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
   connect(ui.browse, &QPushButton::clicked, this, &DesktopPreferencesDialog::onBrowseClicked);
   qDebug("wallpaper: %s", settings.wallpaper().toUtf8().data());
   ui.imageFile->setText(settings.wallpaper());
+  ui.transformImage->setChecked(settings.transformWallpaper());
 
   ui.slideShow->setChecked(settings.slideShowInterval() > 0);
   ui.imageFolder->setText(settings.wallpaperDir());
@@ -157,6 +158,7 @@ void DesktopPreferencesDialog::applySettings()
       XdgDir::setDesktopDir(uiDesktopFolder.desktopFolder->text());
 
   settings.setWallpaper(ui.imageFile->text());
+  settings.setTransformWallpaper(ui.transformImage->isChecked());
   int mode = ui.wallpaperMode->itemData(ui.wallpaperMode->currentIndex()).toInt();
   settings.setWallpaperMode(mode);
 
@@ -212,6 +214,7 @@ void DesktopPreferencesDialog::onWallpaperModeChanged(int index) {
   bool enable = (mode != DesktopWindow::WallpaperNone);
   ui.imageFile->setEnabled(enable);
   ui.browse->setEnabled(enable);
+  ui.transformImage->setEnabled(enable);
 }
 
 void DesktopPreferencesDialog::onBrowseClicked() {

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -157,6 +157,8 @@ private:
     void trustOurDesktopShortcut(std::shared_ptr<const Fm::FileInfo> file);
     bool isTrashCan(std::shared_ptr<const Fm::FileInfo> file);
 
+    QImage getWallpaperImage() const;
+
 private:
     Fm::ProxyFolderModel* proxyModel_;
     Fm::CachedFolderModel* model_;

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -70,6 +70,7 @@ Settings::Settings():
     wallpaperDir_(),
     slideShowInterval_(0),
     wallpaperRandomize_(false),
+    transformWallpaper_(false),
     desktopBgColor_(),
     desktopFgColor_(),
     desktopShadowColor_(),
@@ -225,6 +226,7 @@ bool Settings::loadFile(QString filePath) {
     wallpaperDir_ = settings.value(QStringLiteral("WallpaperDirectory")).toString();
     slideShowInterval_ = settings.value(QStringLiteral("SlideShowInterval"), 0).toInt();
     wallpaperRandomize_ = settings.value(QStringLiteral("WallpaperRandomize")).toBool();
+    transformWallpaper_ = settings.value(QStringLiteral("TransformWallpaper")).toBool();
     desktopBgColor_.setNamedColor(settings.value(QStringLiteral("BgColor"), QStringLiteral("#000000")).toString());
     desktopFgColor_.setNamedColor(settings.value(QStringLiteral("FgColor"), QStringLiteral("#ffffff")).toString());
     desktopShadowColor_.setNamedColor(settings.value(QStringLiteral("ShadowColor"), QStringLiteral("#000000")).toString());
@@ -367,6 +369,7 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue(QStringLiteral("WallpaperDirectory"), wallpaperDir_);
     settings.setValue(QStringLiteral("SlideShowInterval"), slideShowInterval_);
     settings.setValue(QStringLiteral("WallpaperRandomize"), wallpaperRandomize_);
+    settings.setValue(QStringLiteral("TransformWallpaper"), transformWallpaper_);
     settings.setValue(QStringLiteral("BgColor"), desktopBgColor_.name());
     settings.setValue(QStringLiteral("FgColor"), desktopFgColor_.name());
     settings.setValue(QStringLiteral("ShadowColor"), desktopShadowColor_.name());

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -289,6 +289,14 @@ public:
         wallpaperRandomize_ = randomize;
     }
 
+    bool transformWallpaper() const {
+       return transformWallpaper_;
+    }
+
+    void setTransformWallpaper(bool tr) {
+        transformWallpaper_ = tr;
+    }
+
     const QColor& desktopBgColor() const {
         return desktopBgColor_;
     }
@@ -942,6 +950,7 @@ private:
     QString wallpaperDir_;
     int slideShowInterval_;
     bool wallpaperRandomize_;
+    bool transformWallpaper_;
     QColor desktopBgColor_;
     QColor desktopFgColor_;
     QColor desktopShadowColor_;


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt/issues/1714

Jpeg images may contain EXIF info about transformation (rotation and mirroring). An option is added to desktop settings to read the info and transform the wallpaper image accordingly.