### PR TITLE
Set text and icon of delete action of Edit menu on startup

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -167,6 +167,10 @@ MainWindow::MainWindow(Fm::FilePath path):
 
     ui.actionFilter->setChecked(settings.showFilter());
 
+    // menu
+    ui.actionDelete->setText(settings.useTrash() ? tr("&Move to Trash") : tr("&Delete"));
+    ui.actionDelete->setIcon(settings.useTrash() ? QIcon::fromTheme(QStringLiteral("user-trash")) : QIcon::fromTheme(QStringLiteral("edit-delete")));
+
     // side pane
     ui.sidePane->setIconSize(QSize(settings.sidePaneIconSize(), settings.sidePaneIconSize()));
     ui.sidePane->setMode(settings.sidePaneMode());


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/662

Previously, the text (either "Delete" or "Move to Trash") and icon were only set after settings were changed but lost on app startup.

The text and icon of the delete action of right-click menu were always set correctly by libfm-qt.