### PR TITLE
Added menu item to toggle showing of thumbnails on the fly

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -149,6 +149,7 @@
     <addaction name="actionReload"/>
     <addaction name="separator"/>
     <addaction name="actionShowHidden"/>
+    <addaction name="actionShowThumbnails"/>
     <addaction name="actionSplitView"/>
     <addaction name="menuSorting"/>
     <addaction name="menu_View_2"/>
@@ -865,6 +866,20 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+C</string>
+   </property>
+  </action>
+  <action name="actionShowThumbnails">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Thumb&amp;nails</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Thumbnails</string>
    </property>
   </action>
  </widget>

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -166,6 +166,7 @@ MainWindow::MainWindow(Fm::FilePath path):
     connect(ui.actionCloseOther, &QAction::triggered, this, &MainWindow::closeOtherTabs);
 
     ui.actionFilter->setChecked(settings.showFilter());
+    ui.actionShowThumbnails->setChecked(settings.showThumbnails());
 
     // menu
     ui.actionDelete->setText(settings.useTrash() ? tr("&Move to Trash") : tr("&Delete"));
@@ -844,6 +845,10 @@ void MainWindow::on_actionFolderProperties_triggered() {
 void MainWindow::on_actionShowHidden_triggered(bool checked) {
     currentPage()->setShowHidden(checked);
     ui.sidePane->setShowHidden(checked);
+}
+
+void MainWindow::on_actionShowThumbnails_triggered(bool checked) {
+    currentPage()->setShowThumbnails(checked);
 }
 
 void MainWindow::on_actionByFileName_triggered(bool /*checked*/) {

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -140,6 +140,7 @@ protected Q_SLOTS:
 
     void on_actionGo_triggered();
     void on_actionShowHidden_triggered(bool check);
+    void on_actionShowThumbnails_triggered(bool check);
     void on_actionSplitView_triggered(bool check);
     void on_actionPreserveView_triggered(bool checked);
 

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -781,6 +781,14 @@ void TabPage::setShowHidden(bool showHidden) {
     }
 }
 
+void TabPage::setShowThumbnails(bool showThumbnails) {
+    Settings& settings = static_cast<Application*>(qApp)->settings();
+    settings.setShowThumbnails(showThumbnails);
+    if(proxyModel_) {
+        proxyModel_->setShowThumbnails(showThumbnails);
+    }
+}
+
 void TabPage::saveFolderSorting() {
     if (proxyModel_ == nullptr) {
         return;

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -154,6 +154,8 @@ public:
 
     void setShowHidden(bool showHidden);
 
+    void setShowThumbnails(bool showThumbnails);
+
     void saveFolderSorting();
 
     Fm::FilePath path() {


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/375

The change isn't aggressive, meaning that toggling the menu item affects the active tab, new tabs/windows and subsequent sessions but not the other tabs that are already created.

It isn't added to custom folder settings (for now).