### PR TITLE
Wait: Always show display names on Desktop

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -115,8 +115,9 @@ DesktopWindow::DesktopWindow(int screenNum):
         setShadowHidden(settings.shadowHidden());
 
         auto desktopPath = Fm::FilePath::fromLocalPath(XdgDir::readDesktopDir().toStdString().c_str());
-        model_ = Fm::CachedFolderModel::modelFromPath(desktopPath);
-        model_->setShowFullName(settings.showFullNames());
+        model_ = new Fm::FolderModel();
+        model_->setFolder(Fm::Folder::fromPath(desktopPath));
+        model_->setShowFullName(false); // always show display name on Desktop
         folder_ = model_->folder();
         connect(folder_.get(), &Fm::Folder::startLoading, this, &DesktopWindow::onFolderStartLoading);
         connect(folder_.get(), &Fm::Folder::finishLoading, this, &DesktopWindow::onFolderFinishLoading);
@@ -209,7 +210,7 @@ DesktopWindow::~DesktopWindow() {
 
     if(model_) {
         disconnect(model_, &Fm::FolderModel::filesAdded, this, &DesktopWindow::onFilesAdded);
-        model_->unref();
+        delete model_;
     }
 }
 
@@ -471,7 +472,7 @@ void DesktopWindow::setDesktopFolder() {
         if(model_) {
             disconnect(model_, &Fm::FolderModel::filesAdded, this, &DesktopWindow::onFilesAdded);
             proxyModel_->setSourceModel(nullptr);
-            model_->unref(); // unref the cached model
+            delete model_;
             model_ = nullptr;
         }
         disconnect(folder_.get(), nullptr, this, nullptr);
@@ -479,8 +480,9 @@ void DesktopWindow::setDesktopFolder() {
     }
 
     auto path = Fm::FilePath::fromLocalPath(XdgDir::readDesktopDir().toStdString().c_str());
-    model_ = Fm::CachedFolderModel::modelFromPath(path);
-    model_->setShowFullName(static_cast<Application* >(qApp)->settings().showFullNames());
+    model_ = new Fm::FolderModel();
+    model_->setFolder(Fm::Folder::fromPath(path));
+    model_->setShowFullName(false);
     folder_ = model_->folder();
     connect(folder_.get(), &Fm::Folder::startLoading, this, &DesktopWindow::onFolderStartLoading);
     connect(folder_.get(), &Fm::Folder::finishLoading, this, &DesktopWindow::onFolderFinishLoading);

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -161,7 +161,7 @@ private:
 
 private:
     Fm::ProxyFolderModel* proxyModel_;
-    Fm::CachedFolderModel* model_;
+    Fm::FolderModel* model_;
     std::shared_ptr<Fm::Folder> folder_;
     Fm::FolderViewListView* listView_;
 

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -276,8 +276,8 @@ bool Settings::loadFile(QString filePath) {
     showFilter_ = settings.value(QStringLiteral("ShowFilter"), false).toBool();
 
     setBackupAsHidden(settings.value(QStringLiteral("BackupAsHidden"), false).toBool());
-    showFullNames_ = settings.value(QStringLiteral("ShowFullNames"), false).toBool();
-    shadowHidden_ = settings.value(QStringLiteral("ShadowHidden"), false).toBool();
+    showFullNames_ = settings.value(QStringLiteral("ShowFullNames"), true).toBool();
+    shadowHidden_ = settings.value(QStringLiteral("ShadowHidden"), true).toBool();
 
     // override config in libfm's FmConfig
     bigIconSize_ = toIconSize(settings.value(QStringLiteral("BigIconSize"), 48).toInt(), Big);

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -554,7 +554,12 @@ void TabPage::chdir(Fm::FilePath newPath, bool addHistory) {
 
     Settings& settings = static_cast<Application*>(qApp)->settings();
     folderModel_ = CachedFolderModel::modelFromFolder(folder_);
-    folderModel_->setShowFullName(settings.showFullNames());
+    if(strcmp(newPath.uriScheme().get(), "menu") == 0) {
+        folderModel_->setShowFullName(false); // always show display name in menu://applications
+    }
+    else {
+        folderModel_->setShowFullName(settings.showFullNames());
+    }
 
     // folderSettings_ will be set by saveFolderSorting() when the sort filter is changed below
     // (and also by setViewMode()); here, we only need to know whether it should be saved


### PR DESCRIPTION
…in contrast to full names. The reason is that desktop entries have a special usage on Desktop.

In this patch, Desktop (as what is drawn behind all windows) has its own folder model. So, https://github.com/lxqt/libfm-qt/pull/460 is needed for a proper functioning.

Also, two defaults are changed: full names are shown by default inside pcmanfm-qt windows; hidden icons are shadowed by default too.

Closes https://github.com/lxqt/pcmanfm-qt/issues/996

NOTE: Merge/use it only after https://github.com/lxqt/libfm-qt/pull/460 is merged/applied!