### PR TITLE
Release mouse if a dragged tab cannot be dropped

### DIFF
--- a/pcmanfm/tabbar.cpp
+++ b/pcmanfm/tabbar.cpp
@@ -68,19 +68,22 @@ void TabBar::mouseMoveEvent(QMouseEvent *event)
         QMimeData *mimeData = new QMimeData;
         mimeData->setData(QStringLiteral("application/pcmanfm-qt-tab"), QByteArray());
         drag->setMimeData(mimeData);
-        Qt::DropAction dragged = drag->exec();
-        if(dragged == Qt::IgnoreAction) { // a tab is dropped outside all windows
-            if(count() > 1) {
+        int N = count();
+        Qt::DropAction dragged = drag->exec(Qt::MoveAction);
+        if(dragged != Qt::MoveAction) { // a tab is dropped outside all windows
+            if(N > 1) {
                 Q_EMIT tabDetached();
             }
             else {
                 finishMouseMoveEvent();
             }
-            event->accept();
         }
-        else if(dragged == Qt::MoveAction) { // a tab is dropped into another window
-            event->accept();
+        else { // a tab is dropped into another window
+            if(count() == N) {
+                releaseMouse(); // release the mouse if the drop isn't accepted
+            }
         }
+        event->accept();
         drag->deleteLater();
     }
     else {


### PR DESCRIPTION
That shouldn't happen but, rarely, some apps may pretend that they accept any kind of drop while they can't accept pcmanfm-qt's tab drop (Dolphin is an example). This patch is a simple workaround for such cases. By sending a mouse release event, it updates the tab-bar's layout.

@agaida It's safe to have this in 0.15.