### PR TITLE
Follow DE click setting if single-click is not chosen

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -64,7 +64,11 @@ static const char* ifaceName = "org.pcmanfm.Application";
 int ProxyStyle::styleHint(StyleHint hint, const QStyleOption* option, const QWidget* widget, QStyleHintReturn* returnData) const {
     Application* app = static_cast<Application*>(qApp);
     if(hint == QStyle::SH_ItemView_ActivateItemOnSingleClick) {
-        return app->settings().singleClick();
+        if (app->settings().singleClick()) {
+            return true;
+        }
+        // follow the style
+        return QCommonStyle::styleHint(hint,option,widget,returnData);
     }
     return QProxyStyle::styleHint(hint, option, widget, returnData);
 }

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -86,6 +86,9 @@
             </property>
             <item row="0" column="0" colspan="2">
              <widget class="QCheckBox" name="singleClick">
+              <property name="toolTip">
+               <string>If this is unchecked, the DE setting will be used.</string>
+              </property>
               <property name="text">
                <string>Open files with single click</string>
               </property>


### PR DESCRIPTION
This is the simplest and, IMO, best compromise between pcmanfm-qt's and LXQt's settings for single vs. double click. If single-click is chosen, it will be used; if not, the DE setting will be used (`QCommonStyle` gives it automatically), whether inside LXQt or not.

I also added a tooltip to the check-box.

NOTE 1: `QCommonStyle` is used intentionally because widget styles can enforce their click behavior (Kvantum does but I'll change that soon).

NOTE 2: Following the DE setting *completely* is not an option. A file manager should be able to control clicking because opening a file is more than activating a view-item.

→ https://github.com/lxqt/pcmanfm-qt/issues/309