### PR TITLE
More stable position for sticky Desktop Trash

### DIFF
--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -155,9 +155,11 @@ private:
     void createTrash();
     static void onTrashChanged(GFileMonitor* monitor, GFile* gf, GFile* other, GFileMonitorEvent evt, DesktopWindow* pThis);
     void trustOurDesktopShortcut(std::shared_ptr<const Fm::FileInfo> file);
-    bool isTrashCan(std::shared_ptr<const Fm::FileInfo> file);
+    bool isTrashCan(std::shared_ptr<const Fm::FileInfo> file) const;
 
     QImage getWallpaperImage() const;
+
+    QModelIndex indexForPos(bool* isTrash, const QPoint& pos, const QRect& workArea, const QSize& grid) const;
 
 private:
     Fm::ProxyFolderModel* proxyModel_;


### PR DESCRIPTION
Desktop Trash is a special drop target. It will be a little annoying if it is pushed when other items are dropped near it or inside a small empty space of its cell. This patch provides a more stable Trash in two ways:

 1. It prevents a sticky Trash to be moved when other items are dropped near it. Only explicit movements are possible, i.e., by dragging the trash icon.

 2. It trashes dropped items once the drop point is inside the Trash cell — even if it's inside an empty space of that cell.

NOTE: `QListView` ignores empty spaces of cells but our subclassed `FolderViewListView` doesn't and that's a good feature, especially because selection corners are made possible by it.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1007