### PR TITLE
Set the title of slide show dialog

### DIFF
--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -274,6 +274,7 @@ void DesktopPreferencesDialog::onFolderBrowseClicked() {
   dlg.setAcceptMode(QFileDialog::AcceptOpen);
   dlg.setFileMode(QFileDialog::Directory);
   dlg.setOption(QFileDialog::ShowDirsOnly);
+  dlg.setWindowTitle(tr("Select Wallpaper Folder"));
 
   // select an appropriate dir
   QString path = ui.imageFolder->text();


### PR DESCRIPTION
It should be "Select Wallpaper Folder", not "Open File" (the default).