### PR TITLE
Use file launcher to open a folder in new tab

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -143,8 +143,6 @@ DesktopWindow::DesktopWindow(int screenNum):
     listView_->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     listView_->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
-    connect(this, &DesktopWindow::openDirRequested, this, &DesktopWindow::onOpenDirRequested);
-
     listView_->installEventFilter(this);
     listView_->viewport()->installEventFilter(this);
 
@@ -444,16 +442,6 @@ void DesktopWindow::setShadow(const QColor& color) {
     shadowColor_ = color;
     auto delegate = static_cast<Fm::FolderItemDelegate*>(listView_->itemDelegateForColumn(Fm::FolderModel::ColumnFileName));
     delegate->setShadowColor(color);
-}
-
-void DesktopWindow::onOpenDirRequested(const Fm::FilePath& path, int target) {
-    Q_UNUSED(target);
-    // open in new window unconditionally.
-    Application* app = static_cast<Application*>(qApp);
-    MainWindow* newWin = new MainWindow(path);
-    // apply window size from app->settings
-    newWin->resize(app->settings().windowWidth(), app->settings().windowHeight());
-    newWin->show();
 }
 
 void DesktopWindow::resizeEvent(QResizeEvent* event) {

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -107,7 +107,6 @@ protected:
     virtual void paintEvent(QPaintEvent* event) override;
 
 protected Q_SLOTS:
-    void onOpenDirRequested(const Fm::FilePath& path, int target);
     void onDesktopPreferences();
     void onCreatingShortcut();
     void selectAll();

--- a/pcmanfm/launcher.cpp
+++ b/pcmanfm/launcher.cpp
@@ -27,7 +27,8 @@ namespace PCManFM {
 
 Launcher::Launcher(PCManFM::MainWindow* mainWindow):
     Fm::FileLauncher(),
-    mainWindow_(mainWindow) {
+    mainWindow_(mainWindow),
+    openInNewTab_(false) {
 
     Application* app = static_cast<Application*>(qApp);
     setQuickExec(app->settings().quickExec());
@@ -51,7 +52,12 @@ bool Launcher::openFolder(GAppLaunchContext* /*ctx*/, const Fm::FileInfoList& fo
         }
     }
     else {
-        mainWindow->chdir(std::move(path));
+        if(openInNewTab_) {
+            mainWindow->addTab(std::move(path));
+        }
+        else {
+            mainWindow->chdir(std::move(path));
+        }
     }
 
     for(size_t i = 1; i < folderInfos.size(); ++i) {
@@ -61,6 +67,7 @@ bool Launcher::openFolder(GAppLaunchContext* /*ctx*/, const Fm::FileInfoList& fo
     }
     mainWindow->show();
     mainWindow->raise();
+    openInNewTab_ = false;
     return true;
 }
 

--- a/pcmanfm/launcher.h
+++ b/pcmanfm/launcher.h
@@ -32,11 +32,16 @@ public:
     Launcher(MainWindow* mainWindow = nullptr);
     ~Launcher();
 
+    void openInNewTab() {
+        openInNewTab_ = true;
+    }
+
 protected:
     bool openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folderInfos, Fm::GErrorPtr& err) override;
 
 private:
     MainWindow* mainWindow_;
+    bool openInNewTab_;
 };
 
 }

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -642,7 +642,6 @@ int MainWindow::addTabWithPage(TabPage* page, ViewFrame* viewFrame, Fm::FilePath
     int index = viewFrame->getStackedWidget()->addWidget(page);
     connect(page, &TabPage::titleChanged, this, &MainWindow::onTabPageTitleChanged);
     connect(page, &TabPage::statusChanged, this, &MainWindow::onTabPageStatusChanged);
-    connect(page, &TabPage::openDirRequested, this, &MainWindow::onTabPageOpenDirRequested);
     connect(page, &TabPage::sortFilterChanged, this, &MainWindow::onTabPageSortFilterChanged);
     connect(page, &TabPage::backwardRequested, this, &MainWindow::on_actionGoBack_triggered);
     connect(page, &TabPage::forwardRequested, this, &MainWindow::on_actionGoForward_triggered);
@@ -1433,25 +1432,6 @@ void MainWindow::onTabPageStatusChanged(int type, QString statusText) {
     // Since TabPage::statusChanged is always emitted after View::selChanged,
     // there is no need to connect a separate slot to the latter signal
     updateEditSelectedActions();
-}
-
-void MainWindow::onTabPageOpenDirRequested(const Fm::FilePath& path, int target) {
-    TabPage* tabPage = static_cast<TabPage*>(sender());
-    if(ViewFrame* viewFrame = viewFrameForTabPage(tabPage)) {
-        switch(target) {
-        case OpenInCurrentTab:
-            chdir(path, viewFrame);
-            break;
-
-        case OpenInNewTab:
-            addTab(path, viewFrame);
-            break;
-
-        case OpenInNewWindow:
-            (new MainWindow(path))->show();
-            break;
-        }
-    }
 }
 
 void MainWindow::onTabPageSortFilterChanged() { // NOTE: This may be called from context menu too.

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -191,7 +191,6 @@ protected Q_SLOTS:
 
     void onTabPageTitleChanged(QString title);
     void onTabPageStatusChanged(int type, QString statusText);
-    void onTabPageOpenDirRequested(const Fm::FilePath &path, int target);
     void onTabPageSortFilterChanged();
 
     void onSidePaneChdirRequested(int type, const Fm::FilePath &path);

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -128,7 +128,6 @@ TabPage::TabPage(QWidget* parent):
     folderView_->setMargins(settings.folderViewCellMargins());
     folderView_->setShadowHidden(settings.shadowHidden());
     // newView->setColumnWidth(Fm::FolderModel::ColumnName, 200);
-    connect(folderView_, &View::openDirRequested, this, &TabPage::openDirRequested);
     connect(folderView_, &View::selChanged, this, &TabPage::onSelChanged);
     connect(folderView_, &View::clickedBack, this, &TabPage::backwardRequested);
     connect(folderView_, &View::clickedForward, this, &TabPage::forwardRequested);

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -264,7 +264,6 @@ public:
 Q_SIGNALS:
     void statusChanged(int type, QString statusText);
     void titleChanged(QString title);
-    void openDirRequested(const Fm::FilePath& path, int target);
     void sortFilterChanged();
     void forwardRequested();
     void backwardRequested();

--- a/pcmanfm/view.h
+++ b/pcmanfm/view.h
@@ -50,9 +50,6 @@ public:
         Fm::FolderView::setMargins(size);
     }
 
-Q_SIGNALS:
-    void openDirRequested(const Fm::FilePath& path, int target);
-
 protected Q_SLOTS:
     void onNewWindow();
     void onNewTab();


### PR DESCRIPTION
Using the folder path directly might not work, especially in places like `computer:///` or `network:///`, but file launcher is always reliable.

This also simplifies the code a little.

Fixes https://github.com/lxqt/pcmanfm-qt/issues/1019