### PR TITLE
Fix hang when the wallpaper is in tile mode and the file is missing

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -621,14 +621,16 @@ void DesktopWindow::updateWallpaper() {
         QImage image;
         if(wallpaperMode_ == WallpaperTile) { // use the original size
             image = getWallpaperImage();
-            // Note: We can't use the QPainter::drawTiledPixmap(), because it doesn't tile
-            // correctly for background pixmaps bigger than the current screen size.
-            const QSize s = size();
-            pixmap = QPixmap{s};
-            QPainter painter{&pixmap};
-            for (int x = 0; x < s.width(); x += image.width()) {
-                for (int y = 0; y < s.height(); y += image.height()) {
-                    painter.drawImage(x, y, image);
+            if (!image.isNull()) {
+                // Note: We can't use the QPainter::drawTiledPixmap(), because it doesn't tile
+                // correctly for background pixmaps bigger than the current screen size.
+                const QSize s = size();
+                pixmap = QPixmap{s};
+                QPainter painter{&pixmap};
+                for (int x = 0; x < s.width(); x += image.width()) {
+                    for (int y = 0; y < s.height(); y += image.height()) {
+                        painter.drawImage(x, y, image);
+                    }
                 }
             }
         }


### PR DESCRIPTION
s.width() and s.height() are zero, so pcmanfm-qt hangs in an infinite
loop.

Noticed this when the partition with my wallpaper fails to mount.