### PR TITLE
Add option for transparent desktop background

### DIFF
--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -56,6 +56,7 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
   ui.wallpaperMode->addItem(tr("Center on the screen"), DesktopWindow::WallpaperCenter);
   ui.wallpaperMode->addItem(tr("Tile the image to fill the entire screen"), DesktopWindow::WallpaperTile);
   ui.wallpaperMode->addItem(tr("Zoom the image to fill the entire screen"), DesktopWindow::WallpaperZoom);
+  ui.wallpaperMode->addItem(tr("Transparent background (requires compositor)"), DesktopWindow::WallpaperTransparent);
   int i;
   switch(settings.wallpaperMode()) {
     case DesktopWindow::WallpaperNone:
@@ -75,6 +76,9 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
       break;
     case DesktopWindow::WallpaperZoom:
       i = 5;
+      break;
+    case DesktopWindow::WallpaperTransparent:
+      i = 6;
       break;
     default:
       i = 0;
@@ -223,7 +227,7 @@ void DesktopPreferencesDialog::accept() {
 void DesktopPreferencesDialog::onWallpaperModeChanged(int index) {
   int mode = ui.wallpaperMode->itemData(index).toInt();
 
-  bool enable = (mode != DesktopWindow::WallpaperNone);
+  bool enable = (mode != DesktopWindow::WallpaperNone && mode != DesktopWindow::WallpaperTransparent);
   ui.imageFile->setEnabled(enable);
   ui.browse->setEnabled(enable);
   ui.transformImage->setEnabled(enable);

--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -86,6 +86,7 @@ DesktopWindow::DesktopWindow(int screenNum):
     setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
     setAttribute(Qt::WA_X11NetWmWindowTypeDesktop);
     setAttribute(Qt::WA_DeleteOnClose);
+    setAttribute(Qt::WA_TranslucentBackground);
 
     // set our custom file launcher
     View::setFileLauncher(&fileLauncher_);
@@ -449,7 +450,7 @@ void DesktopWindow::resizeEvent(QResizeEvent* event) {
     QWidget::resizeEvent(event);
 
     // resize wall paper if needed
-    if(isVisible() && wallpaperMode_ != WallpaperNone && wallpaperMode_ != WallpaperTile) {
+    if(isVisible() && wallpaperMode_ != WallpaperNone && wallpaperMode_ != WallpaperTile && wallpaperMode_ != WallpaperTransparent) {
         updateWallpaper();
         update();
     }
@@ -616,7 +617,7 @@ QImage DesktopWindow::loadWallpaperFile(QSize requiredSize) {
 
 // really generate the background pixmap according to current settings and apply it.
 void DesktopWindow::updateWallpaper() {
-    if(wallpaperMode_ != WallpaperNone) {  // use wallpaper
+    if(wallpaperMode_ != WallpaperNone && wallpaperMode_ != WallpaperTransparent) {  // use wallpaper
         QPixmap pixmap;
         QImage image;
         Settings& settings = static_cast<Application* >(qApp)->settings();
@@ -1201,6 +1202,10 @@ void DesktopWindow::paintBackground(QPaintEvent* event) {
     // https://bugreports.qt.io/browse/QTBUG-54384
     QPainter painter(this);
     if(wallpaperMode_ == WallpaperNone || wallpaperPixmap_.isNull()) {
+        painter.fillRect(event->rect(), QBrush(bgColor_));
+    }
+    else if (wallpaperMode_ == WallpaperTransparent) {
+        painter.setOpacity(0.0);
         painter.fillRect(event->rect(), QBrush(bgColor_));
     }
     else {

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -54,7 +54,8 @@ public:
         WallpaperFit,
         WallpaperCenter,
         WallpaperTile,
-        WallpaperZoom
+        WallpaperZoom,
+        WallpaperTransparent
     };
 
     explicit DesktopWindow(int screenNum);

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -677,6 +677,9 @@ static const char* wallpaperModeToString(int value) {
     case DesktopWindow::WallpaperZoom:
         ret = "zoom";
         break;
+    case DesktopWindow::WallpaperTransparent:
+        ret = "transparent";
+        break;
     }
     return ret;
 }
@@ -697,6 +700,9 @@ static int wallpaperModeFromString(const QString str) {
     }
     else if(str == QLatin1String("zoom")) {
         ret = DesktopWindow::WallpaperZoom;
+    }
+    else if(str == QLatin1String("transparent")) {
+        ret = DesktopWindow::WallpaperTransparent;
     }
     else {
         ret = DesktopWindow::WallpaperNone;


### PR DESCRIPTION
Allows for using other background manages or placing [status] windows
below the desktop and still being able to see them. Doing so is probably
not advised but seems to work OK.

Unfortunately know neither QT5 nor C++ so the patch probably needs some work / cleanup, apologies. Also probably a very niche use case, but being only ~20 lines it might still be worth adding (xfdesktop seems to have a "transparent" option looking at the UI but not sure if it's supposed to do quite the same thing).