### PR TITLE
Focus side-pane with `Ctrl+Esc`

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -276,6 +276,13 @@ MainWindow::MainWindow(Fm::FilePath path):
         }
     });
 
+    shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Escape), this);
+    connect(shortcut, &QShortcut::activated, [this] {
+        if(ui.sidePane->isVisible() && ui.sidePane->view()) {
+            ui.sidePane->view()->setFocus();
+        }
+    });
+
     shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_L), this);
     connect(shortcut, &QShortcut::activated, this, &MainWindow::focusPathEntry);
 


### PR DESCRIPTION
Good with keyboard-only navigation. `Esc` is already used to focus the view, so `Ctrl+Esc` seems good to focus the side-pane.

Relies on https://github.com/lxqt/libfm-qt/pull/525

Closes https://github.com/lxqt/pcmanfm-qt/issues/1076