### PR TITLE
Added Hidden Shortcuts dialog

### DIFF
--- a/pcmanfm/CMakeLists.txt
+++ b/pcmanfm/CMakeLists.txt
@@ -34,6 +34,7 @@ set_source_files_properties(${pcmanfm_DBUS_SRCS} PROPERTIES SKIP_AUTOGEN ON)
 set(pcmanfm_UIS
     main-win.ui
     about.ui
+    shortcuts.ui
     preferences.ui
     desktop-preferences.ui
     desktop-folder.ui

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -92,6 +92,7 @@
      <string>&amp;Help</string>
     </property>
     <addaction name="actionAbout"/>
+    <addaction name="actionHiddenShortcuts"/>
    </widget>
    <widget class="QMenu" name="menu_View">
     <property name="title">
@@ -901,6 +902,11 @@
    </property>
    <property name="shortcut">
     <string>F9</string>
+   </property>
+  </action>
+  <action name="actionHiddenShortcuts">
+   <property name="text">
+    <string>Hidden &amp;Shortcuts</string>
    </property>
   </action>
  </widget>

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -47,6 +47,7 @@
 #include <libfm-qt/core/fileinfo.h>
 #include <libfm-qt/mountoperation.h>
 #include "ui_about.h"
+#include "ui_shortcuts.h"
 #include "application.h"
 #include "bulkrename.h"
 
@@ -1026,6 +1027,24 @@ void MainWindow::on_actionAbout_triggered() {
         Ui::AboutDialog ui;
     };
     AboutDialog dialog(this);
+    dialog.exec();
+}
+
+void MainWindow::on_actionHiddenShortcuts_triggered() {
+    class HiddenShortcutsDialog : public QDialog {
+    public:
+        explicit HiddenShortcutsDialog(QWidget* parent = 0, Qt::WindowFlags f = 0) : QDialog(parent, f) {
+            ui.setupUi(this);
+            ui.treeWidget->setRootIsDecorated(false);
+            ui.treeWidget->header()->setSectionResizeMode(QHeaderView::Stretch);
+            ui.treeWidget->header()->setSectionsClickable(true);
+            ui.treeWidget->sortByColumn(1, Qt::AscendingOrder);
+            ui.treeWidget->setSortingEnabled(true);
+        }
+    private:
+        Ui::HiddenShortcutsDialog ui;
+    };
+    HiddenShortcutsDialog dialog(this);
     dialog.exec();
 }
 

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -177,6 +177,7 @@ protected Q_SLOTS:
     void on_actionFindFiles_triggered();
 
     void on_actionAbout_triggered();
+    void on_actionHiddenShortcuts_triggered();
 
     void onBookmarkActionTriggered();
 

--- a/pcmanfm/shortcuts.ui
+++ b/pcmanfm/shortcuts.ui
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>HiddenShortcutsDialog</class>
+ <widget class="QDialog" name="HiddenShortcutsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Hidden Shortcuts</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTreeWidget" name="treeWidget">
+     <column>
+      <property name="text">
+       <string>Shortcut</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Action</string>
+      </property>
+     </column>
+     <item>
+      <property name="text">
+       <string>Esc</string>
+      </property>
+      <property name="text">
+       <string>Focus view, clear filter bar</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Ctrl+Esc</string>
+      </property>
+      <property name="text">
+       <string>Focus side-pane</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Ctrl+L</string>
+      </property>
+      <property name="text">
+       <string>Focus path entry</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Alt+D</string>
+      </property>
+      <property name="text">
+       <string>Focus path entry</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Ctrl+Tab</string>
+      </property>
+      <property name="text">
+       <string>Next tab</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Ctrl+Shift+Tab</string>
+      </property>
+      <property name="text">
+       <string>Previous tab</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Ctrl+PageDown</string>
+      </property>
+      <property name="text">
+       <string>Next tab</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Ctrl+PageUp</string>
+      </property>
+      <property name="text">
+       <string>Previous tab</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Ctrl+Number</string>
+      </property>
+      <property name="text">
+       <string>Jump to tab</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Alt+Number</string>
+      </property>
+      <property name="text">
+       <string>Jump to tab</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Backspace</string>
+      </property>
+      <property name="text">
+       <string>Go up</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Ctrl+F</string>
+      </property>
+      <property name="text">
+       <string>Search dialog</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Shift+Insert</string>
+      </property>
+      <property name="text">
+       <string>Paste into transient filter bar</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>HiddenShortcutsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>HiddenShortcutsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Its menu item is below "About".

pcmanfm-qt has several useful shortcuts that aren't shown in its GUI. We can't expect users to find them by reading the source code or (nonexistent) help doc. Moreover, the user may have forgotten this or that hidden shortcut.

Relies on https://github.com/lxqt/pcmanfm-qt/pull/1078 for one shortcut.