### PR TITLE
Added an option for single window mode

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -505,7 +505,7 @@ void Application::connectToServer() {
     dlg->show();
 }
 
-void Application::launchFiles(QString cwd, QStringList paths, bool /*inNewWindow*/) {
+void Application::launchFiles(QString cwd, QStringList paths, bool inNewWindow) {
     Fm::FilePathList pathList;
     Fm::FilePath cwd_path;
     QStringList::iterator it;
@@ -530,7 +530,26 @@ void Application::launchFiles(QString cwd, QStringList paths, bool /*inNewWindow
        pathList.push_back(std::move(path));
     }
 
-    Launcher(nullptr).launchPaths(nullptr, pathList);
+    if(!inNewWindow && settings_.singleWindowMode()) {
+        MainWindow* window = MainWindow::lastActive();
+        // if there is no last active window, find the last created window
+        if(window == nullptr) {
+            QWidgetList windows = topLevelWidgets();
+            for(int i = 0; i < windows.size(); ++i) {
+                auto win = windows.at(windows.size() - 1 - i);
+                if(win->inherits("PCManFM::MainWindow")) {
+                    window = static_cast<MainWindow*>(win);
+                    break;
+                }
+            }
+        }
+        auto launcher = Launcher(window);
+        launcher.openInNewTab();
+        launcher.launchPaths(nullptr, pathList);
+    }
+    else {
+        Launcher(nullptr).launchPaths(nullptr, pathList);
+    }
 }
 
 void Application::openFolders(Fm::FileInfoList files) {

--- a/pcmanfm/launcher.cpp
+++ b/pcmanfm/launcher.cpp
@@ -67,6 +67,7 @@ bool Launcher::openFolder(GAppLaunchContext* /*ctx*/, const Fm::FileInfoList& fo
     }
     mainWindow->show();
     mainWindow->raise();
+    mainWindow->activateWindow();
     openInNewTab_ = false;
     return true;
 }

--- a/pcmanfm/launcher.h
+++ b/pcmanfm/launcher.h
@@ -32,6 +32,10 @@ public:
     Launcher(MainWindow* mainWindow = nullptr);
     ~Launcher();
 
+    bool hasMainWindow() const {
+        return mainWindow_ != nullptr;
+    }
+
     void openInNewTab() {
         openInNewTab_ = true;
     }

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -117,7 +117,7 @@ void ViewFrame::removeTopBar() {
 //======================================================================
 
 // static
-MainWindow* MainWindow::lastActive_ = nullptr;
+QPointer<MainWindow> MainWindow::lastActive_;
 
 MainWindow::MainWindow(Fm::FilePath path):
     QMainWindow(),

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -21,6 +21,7 @@
 #define FM_MAIN_WINDOW_H
 
 #include "ui_main-win.h"
+#include <QPointer>
 #include <QMainWindow>
 #include <QListView>
 #include <QSortFilterProxyModel>
@@ -268,7 +269,7 @@ private:
     // not from another window. So, we get the mode at the start and keep it.
     bool splitView_;
 
-    static MainWindow* lastActive_;
+    static QPointer<MainWindow> lastActive_;
 };
 
 }

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -214,6 +214,16 @@
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QCheckBox" name="singleWindowMode">
+              <property name="toolTip">
+               <string>Open folders in new tabs as far as possible</string>
+              </property>
+              <property name="text">
+               <string>Single window mode</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>
@@ -469,7 +479,7 @@ A space is also reserved for 3 lines of text.</string>
         </layout>
        </widget>
        <widget class="QWidget" name="uiPage">
-        <layout class="QVBoxLayout" name="verticalLayout_5" stretch="0,0,1">
+        <layout class="QVBoxLayout" name="verticalLayout_5" stretch="0,1">
          <item>
           <widget class="QGroupBox" name="groupBox_5">
            <property name="title">

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -224,6 +224,7 @@ void PreferencesDialog::initBehaviorPage(Settings& settings) {
     ui.confirmTrash->setChecked(settings.confirmTrash());
     ui.quickExec->setChecked(settings.quickExec());
     ui.selectNewFiles->setChecked(settings.selectNewFiles());
+    ui.singleWindowMode->setChecked(settings.singleWindowMode());
 
     // app restart warning
     connect(ui.quickExec, &QAbstractButton::toggled, [this, &settings] (bool checked) {
@@ -338,6 +339,7 @@ void PreferencesDialog::applyBehaviorPage(Settings& settings) {
     settings.setConfirmTrash(ui.confirmTrash->isChecked());
     settings.setQuickExec(ui.quickExec->isChecked());
     settings.setSelectNewFiles(ui.selectNewFiles->isChecked());
+    settings.setSingleWindowMode(ui.singleWindowMode->isChecked());
 }
 
 void PreferencesDialog::applyThumbnailPage(Settings& settings) {

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -55,6 +55,7 @@ Settings::Settings():
     supportTrash_(Fm::uriExists("trash:///")), // check if trash:/// is supported
     fallbackIconThemeName_(),
     useFallbackIconTheme_(QIcon::themeName().isEmpty() || QIcon::themeName() == QLatin1String("hicolor")),
+    singleWindowMode_(false),
     bookmarkOpenMethod_(OpenInCurrentTab),
     suCommand_(),
     terminal_(),
@@ -212,6 +213,7 @@ bool Settings::loadFile(QString filePath) {
     settings.endGroup();
 
     settings.beginGroup(QStringLiteral("Behavior"));
+    singleWindowMode_ = settings.value(QStringLiteral("SingleWindowMode"), false).toBool();
     bookmarkOpenMethod_ = bookmarkOpenMethodFromString(settings.value(QStringLiteral("BookmarkOpenMethod")).toString());
     // settings for use with libfm
     useTrash_ = settings.value(QStringLiteral("UseTrash"), true).toBool();
@@ -360,6 +362,7 @@ bool Settings::saveFile(QString filePath) {
     settings.endGroup();
 
     settings.beginGroup(QStringLiteral("Behavior"));
+    settings.setValue(QStringLiteral("SingleWindowMode"), singleWindowMode_);
     settings.setValue(QStringLiteral("BookmarkOpenMethod"), QString::fromUtf8(bookmarkOpenMethodToString(bookmarkOpenMethod_)));
     // settings for use with libfm
     settings.setValue(QStringLiteral("UseTrash"), useTrash_);

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -175,6 +175,14 @@ public:
         fallbackIconThemeName_ = iconThemeName;
     }
 
+    bool singleWindowMode() const {
+        return singleWindowMode_;
+    }
+
+    void setSingleWindowMode(bool singleWindowMode) {
+        singleWindowMode_ = singleWindowMode;
+    }
+
     OpenDirTargetType bookmarkOpenMethod() {
         return bookmarkOpenMethod_;
     }
@@ -986,6 +994,7 @@ private:
     QString fallbackIconThemeName_;
     bool useFallbackIconTheme_;
 
+    bool singleWindowMode_;
     OpenDirTargetType bookmarkOpenMethod_;
     QString suCommand_;
     QString terminal_;

--- a/pcmanfm/view.h
+++ b/pcmanfm/view.h
@@ -62,6 +62,7 @@ protected:
     virtual void prepareFolderMenu(Fm::FolderMenu* menu);
 
 private:
+    void launchFiles(Fm::FileInfoList files, bool inNewTabs = false);
 
 };
 


### PR DESCRIPTION
With the option enabled, folders will be opened in new tabs of an existing window (the last focused or created window) if an external app calls pcmanfm-qt, the command-line is used, or folders are clicked on desktop.

The option is disabled by default.

The user could still open folders in new windows by using the context menu or adding the `-n/--new-window` command-line option. Actually, `-n/--new-window` makes sense only after this change.

Also, the pointer to the last active window is changed to a guarded pointer. An ordinary pointer was a potential cause of crash but, luckily, it couldn't cause a crash before this feature.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1094 and fixes https://github.com/lxqt/pcmanfm-qt/issues/1096