### PR TITLE
Prevented total freeze with auto-mounting of encrypted volumes

### DIFF
--- a/pcmanfm/application.h
+++ b/pcmanfm/application.h
@@ -128,6 +128,7 @@ private Q_SLOTS:
 private:
     void initWatch();
     void installSigtermHandler();
+    void reallyInitVolumeManager();
 
     bool isPrimaryInstance;
     Fm::LibFmQt libFm_;

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -35,6 +35,7 @@
 #include "tabbar.h"
 #include <libfm-qt/core/filepath.h>
 #include <libfm-qt/core/bookmarks.h>
+#include <libfm-qt/mountoperation.h>
 
 namespace Fm {
 class PathEdit;
@@ -101,6 +102,8 @@ public:
     static MainWindow* lastActive() {
         return lastActive_;
     }
+
+    QList<Fm::MountOperation*> pendingMountOperations() const;
 
 protected Q_SLOTS:
 


### PR DESCRIPTION
Fixes https://github.com/lxqt/pcmanfm-qt/issues/1106

If the user tries to mount a volume in the short time before auto-mounting is started — and that's especially possible with an encrypted volume — a complete freeze might happen because `MountOperation::wait()` uses a local `QEventLoop`. Therefore, we need to start auto-mounting only after all probable GUI mount operations are finished.

The above-mentioned scenario was practically impossible with the desktop mode and so, LXQt users didn't encounter it. But it would be possible if pcmanfm-qt was used outside an LXQt session.