### PR TITLE
Fix mismatch in lang code from filename.

### DIFF
--- a/pcmanfm/translations/pcmanfm-qt-desktop-pref_ko.desktop
+++ b/pcmanfm/translations/pcmanfm-qt-desktop-pref_ko.desktop
@@ -1,4 +1,4 @@
 #Translations
-Name[ja]=바탕 화면
-GenericName[ja]=바탕 화면
-Comment[ja]=배경 화면 및 기타 데스크톱 설정을 변경합니다 (PCManFM-Qt)
+Name[ko]=바탕 화면
+GenericName[ko]=바탕 화면
+Comment[ko]=배경 화면 및 기타 데스크톱 설정을 변경합니다 (PCManFM-Qt)

--- a/pcmanfm/translations/pcmanfm-qt_ko.desktop
+++ b/pcmanfm/translations/pcmanfm-qt_ko.desktop
@@ -1,4 +1,4 @@
 #Translations
-Name[ja]=PCManFM-Qt 파일 관리자
-GenericName[ja]=파일 관리자 Qt
-Comment[ja]=파일이나 파일 시스템을 관리합니다 (PCManFM-Qt)
+Name[ko]=PCManFM-Qt 파일 관리자
+GenericName[ko]=파일 관리자 Qt
+Comment[ko]=파일이나 파일 시스템을 관리합니다 (PCManFM-Qt)


### PR DESCRIPTION
The Lubuntu CI has thrown these warnings in the past several days:
```
W: pcmanfm-qt: duplicate-key-in-desktop usr/share/applications/pcmanfm-qt-desktop-pref.desktop:48 Name[ja]
W: pcmanfm-qt: duplicate-key-in-desktop usr/share/applications/pcmanfm-qt-desktop-pref.desktop:49 GenericName[ja]
W: pcmanfm-qt: duplicate-key-in-desktop usr/share/applications/pcmanfm-qt-desktop-pref.desktop:50 Comment[ja]
W: pcmanfm-qt: duplicate-key-in-desktop usr/share/applications/pcmanfm-qt.desktop:50 Name[ja]
W: pcmanfm-qt: duplicate-key-in-desktop usr/share/applications/pcmanfm-qt.desktop:51 GenericName[ja]
W: pcmanfm-qt: duplicate-key-in-desktop usr/share/applications/pcmanfm-qt.desktop:52 Comment[ja]
```

Sure enough, 19494f1fb26c5b7f2d2380bd70d8065e3ed4617b adds Korean translations but in 2/3 files the lang code is `ja`, not `ko`.

This fixes that. Ref #1152 