### PR TITLE
Unminimize window when switching to new tab is enabled

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -664,6 +664,10 @@ int MainWindow::addTabWithPage(TabPage* page, ViewFrame* viewFrame, Fm::FilePath
     Settings& settings = static_cast<Application*>(qApp)->settings();
     if(settings.switchToNewTab()) {
         viewFrame->getTabBar()->setCurrentIndex(index);
+        if (isMinimized()) {
+            setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+            show();
+        }
     }
     if(!settings.alwaysShowTabs()) {
         viewFrame->getTabBar()->setVisible(viewFrame->getTabBar()->count() > 1);


### PR DESCRIPTION
When the user enables switching to newly created tab, the window shouldn't be left minimized when a new tab is added. This is mostly relevant to the single window mode but isn't limited to it.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1109