### PR TITLE
Added an option to open tabs of last window

### DIFF
--- a/pcmanfm/application.h
+++ b/pcmanfm/application.h
@@ -73,7 +73,7 @@ public:
     }
 
     // public interface exported via dbus
-    void launchFiles(QString cwd, QStringList paths, bool inNewWindow);
+    void launchFiles(QString cwd, QStringList paths, bool inNewWindow, bool reopenLastTabs);
     void setWallpaper(QString path, QString modeString);
     void preferences(QString page);
     void desktopPrefrences(QString page);

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -1188,6 +1188,23 @@ void MainWindow::closeEvent(QCloseEvent* event) {
             settings.setLastWindowHeight(height());
         }
     }
+
+    // remember last tab paths only if this is the last window
+    QStringList tabPaths;
+    if(lastActive_ == nullptr && settings.reopenLastTabs()) {
+        for(int i = 0; i < ui.viewSplitter->count(); ++i) {
+            if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(ui.viewSplitter->widget(i))) {
+                int n = viewFrame->getStackedWidget()->count();
+                for(int j = 0; j < n; ++j) {
+                    if(TabPage* page = static_cast<TabPage*>(viewFrame->getStackedWidget()->widget(j))) {
+                        tabPaths.append(QString::fromUtf8(page->path().toString().get()));
+                    }
+                }
+            }
+        }
+        tabPaths.removeDuplicates();
+    }
+    settings.setTabPaths(tabPaths);
 }
 
 void MainWindow::onTabBarCurrentChanged(int index) {

--- a/pcmanfm/org.pcmanfm.Application.xml
+++ b/pcmanfm/org.pcmanfm.Application.xml
@@ -14,6 +14,7 @@
       <arg type="s" direction="in"/>
       <arg type="as" direction="in"/>
       <arg type="b" direction="in"/>
+      <arg type="b" direction="in"/>
     </method>
     <method name="quit">
     </method>

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -556,6 +556,13 @@ only if there are more than one tab.</string>
               </property>
              </widget>
             </item>
+            <item row="6" column="0" colspan="2">
+             <widget class="QCheckBox" name="reopenLastTabs">
+              <property name="text">
+               <string>Reopen last tabs in first window</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -559,7 +559,7 @@ only if there are more than one tab.</string>
             <item row="6" column="0" colspan="2">
              <widget class="QCheckBox" name="reopenLastTabs">
               <property name="text">
-               <string>Reopen last tabs in first window</string>
+               <string>Reopen last window tabs in a new window</string>
               </property>
              </widget>
             </item>

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -184,6 +184,7 @@ void PreferencesDialog::initUiPage(Settings& settings) {
     ui.alwaysShowTabs->setChecked(settings.alwaysShowTabs());
     ui.showTabClose->setChecked(settings.showTabClose());
     ui.switchToNewTab->setChecked(settings.switchToNewTab());
+    ui.reopenLastTabs->setChecked(settings.reopenLastTabs());
     ui.rememberWindowSize->setChecked(settings.rememberWindowSize());
     ui.fixedWindowWidth->setValue(settings.fixedWindowWidth());
     ui.fixedWindowHeight->setValue(settings.fixedWindowHeight());
@@ -318,6 +319,7 @@ void PreferencesDialog::applyUiPage(Settings& settings) {
     settings.setAlwaysShowTabs(ui.alwaysShowTabs->isChecked());
     settings.setShowTabClose(ui.showTabClose->isChecked());
     settings.setSwitchToNewTab(ui.switchToNewTab->isChecked());
+    settings.setReopenLastTabs(ui.reopenLastTabs->isChecked());
     settings.setRememberWindowSize(ui.rememberWindowSize->isChecked());
     settings.setFixedWindowWidth(ui.fixedWindowWidth->value());
     settings.setFixedWindowHeight(ui.fixedWindowHeight->value());

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -86,6 +86,7 @@ Settings::Settings():
     alwaysShowTabs_(true),
     showTabClose_(true),
     switchToNewTab_(false),
+    reopenLastTabs_(false),
     rememberWindowSize_(true),
     fixedWindowWidth_(640),
     fixedWindowHeight_(480),
@@ -332,6 +333,8 @@ bool Settings::loadFile(QString filePath) {
     alwaysShowTabs_ = settings.value(QStringLiteral("AlwaysShowTabs"), true).toBool();
     showTabClose_ = settings.value(QStringLiteral("ShowTabClose"), true).toBool();
     switchToNewTab_ = settings.value(QStringLiteral("SwitchToNewTab"), false).toBool();
+    reopenLastTabs_ = settings.value(QStringLiteral("ReopenLastTabs"), false).toBool();
+    tabPaths_ = settings.value(QStringLiteral("TabPaths")).toStringList();
     splitterPos_ = settings.value(QStringLiteral("SplitterPos"), 150).toInt();
     sidePaneVisible_ = settings.value(QStringLiteral("SidePaneVisible"), true).toBool();
     sidePaneMode_ = sidePaneModeFromString(settings.value(QStringLiteral("SidePaneMode")).toString());
@@ -462,7 +465,7 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue(QStringLiteral("PlacesRoot"), placesRoot_);
     settings.setValue(QStringLiteral("PlacesComputer"), placesComputer_);
     settings.setValue(QStringLiteral("PlacesNetwork"), placesNetwork_);
-    if (hiddenPlaces_.isEmpty()) {  // don't save "@Invalid()"
+    if(hiddenPlaces_.isEmpty()) { // don't save "@Invalid()"
         settings.remove(QStringLiteral("HiddenPlaces"));
     }
     else {
@@ -481,6 +484,13 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue(QStringLiteral("AlwaysShowTabs"), alwaysShowTabs_);
     settings.setValue(QStringLiteral("ShowTabClose"), showTabClose_);
     settings.setValue(QStringLiteral("SwitchToNewTab"), switchToNewTab_);
+    settings.setValue(QStringLiteral("ReopenLastTabs"), reopenLastTabs_);
+    if(tabPaths_.isEmpty()) { // don't save "@Invalid()" {
+        settings.remove(QStringLiteral("TabPaths"));
+    }
+    else {
+        settings.setValue(QStringLiteral("TabPaths"), tabPaths_);
+    }
     settings.setValue(QStringLiteral("SplitterPos"), splitterPos_);
     settings.setValue(QStringLiteral("SidePaneVisible"), sidePaneVisible_);
     settings.setValue(QStringLiteral("SidePaneMode"), QString::fromUtf8(sidePaneModeToString(sidePaneMode_)));

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -445,6 +445,22 @@ public:
         switchToNewTab_ = showTabClose;
     }
 
+    bool reopenLastTabs() const {
+        return reopenLastTabs_;
+    }
+
+    void setReopenLastTabs(bool reopenLastTabs) {
+        reopenLastTabs_ = reopenLastTabs;
+    }
+
+    QStringList tabPaths() const {
+        return tabPaths_;
+    }
+
+    void setTabPaths(const QStringList& tabPaths) {
+        tabPaths_ = tabPaths;
+    }
+
     bool rememberWindowSize() const {
         return rememberWindowSize_;
     }
@@ -1046,6 +1062,8 @@ private:
     bool alwaysShowTabs_;
     bool showTabClose_;
     bool switchToNewTab_;
+    bool reopenLastTabs_;
+    QStringList tabPaths_;
     bool rememberWindowSize_;
     int fixedWindowWidth_;
     int fixedWindowHeight_;


### PR DESCRIPTION
This PR supersedes https://github.com/lxqt/pcmanfm-qt/pull/1174 because explaining all details there would take much more time and energy than making a clean PR.

When the new option is checked (it's unchecked by default), the following behaviors are implemented:

 1. The first window loads the tabs of the last closed window (and nothing else). Subsequent windows are opened in the usual way until the last window is closed and its tabs are remembered.

 2. If some folders are opened in the first window *explicitly*  (e.g., by clicking a desktop folder or adding paths to command-line), the last tabs will be ignored with it but they will be reopened in the next window that doesn't explicitly open a folder. That's intentional because the feature shouldn't interfere with opening of folders.

 3. If some folders of the last tabs are removed or inaccessible, libfm-qt's error messages will be shown. They inform the user about the non-existing folders without opening empty tabs. If all folders are inaccessible and there is no window yet, the current work directory will be opened.