### PR TITLE
Fixed regression in restoring vertical scroll position

### DIFF
--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -314,9 +314,7 @@ void TabPage::onFolderStartLoading() {
 }
 
 void TabPage::onUiUpdated() {
-    // scroll to recorded position
-    folderView_->childView()->verticalScrollBar()->setValue(browseHistory().currentScrollPos());
-
+    bool scrolled = false;
     // if the current folder is the parent folder of the last browsed folder,
     // select the folder item in current view.
     if(lastFolderPath_ && lastFolderPath_.parent() == path()) {
@@ -324,13 +322,17 @@ void TabPage::onUiUpdated() {
         if(index.isValid()) {
             folderView_->childView()->scrollTo(index, QAbstractItemView::EnsureVisible);
             folderView_->childView()->setCurrentIndex(index);
+            scrolled = true;
         }
     }
-    else { // set the first item as current
+    if(!scrolled) {
+        // set the first item as current
         QModelIndex firstIndx = proxyModel_->index(0, 0);
         if (firstIndx.isValid()) {
             folderView_->selectionModel()->setCurrentIndex(firstIndx, QItemSelectionModel::NoUpdate);
         }
+        // scroll to recorded position
+        folderView_->childView()->verticalScrollBar()->setValue(browseHistory().currentScrollPos());
     }
 
     if(folderModel_) {


### PR DESCRIPTION
Restoring the vertical scroll position after reloading a folder was a nice feature that was damaged after https://github.com/lxqt/pcmanfm-qt/commit/e6065e345825bfa733f816c7e65c5c40a17e7107. The reason was that the `autoScroll` property of the item view is `true` and so, giving the focus to the first item made the view scroll to the top.

This patch fixes the regression by restoring the vertical scroll position only after setting the current item.