### PR TITLE
Keep current focus when opening new tab in background

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -676,9 +676,9 @@ int MainWindow::addTabWithPage(TabPage* page, ViewFrame* viewFrame, Fm::FilePath
 }
 
 // add a new tab
-int MainWindow::addTab(Fm::FilePath path, ViewFrame* viewFrame) {
+void MainWindow::addTab(Fm::FilePath path, ViewFrame* viewFrame) {
     TabPage* newPage = new TabPage(this);
-    return addTabWithPage(newPage, viewFrame, path);
+    addTabWithPage(newPage, viewFrame, path);
 }
 
 void MainWindow::toggleMenuBar(bool /*checked*/) {

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -85,8 +85,8 @@ public:
         chdir(path, activeViewFrame_);
     }
 
-    int addTab(Fm::FilePath path, ViewFrame* viewFrame);
-    int addTab(Fm::FilePath path) {
+    void addTab(Fm::FilePath path, ViewFrame* viewFrame);
+    void addTab(Fm::FilePath path) {
         return addTab(path, activeViewFrame_);
     }
 

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -87,7 +87,7 @@ public:
 
     void addTab(Fm::FilePath path, ViewFrame* viewFrame);
     void addTab(Fm::FilePath path) {
-        return addTab(path, activeViewFrame_);
+        addTab(path, activeViewFrame_);
     }
 
     TabPage* currentPage(ViewFrame* viewFrame) {

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -824,7 +824,9 @@ void TabPage::setViewMode(Fm::FolderView::ViewMode mode) {
     }
     Fm::FolderView::ViewMode prevMode = folderView_->viewMode();
     folderView_->setViewMode(mode);
-    folderView_->childView()->setFocus();
+    if(folderView_->isVisible()) { // in the current tab
+        folderView_->childView()->setFocus();
+    }
     if(prevMode != folderView_->viewMode()) {
         // FolderView::setViewMode() may delete the view to switch between list and tree.
         // So, the event filter should be re-installed and the status message should be updated.


### PR DESCRIPTION
Previously, the new tab took away the focus in the background and that could be quite confusing, especially when the keyboard was used.