### PR TITLE
Handle ampersand and newline in tab text

### DIFF
--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -195,7 +195,7 @@ protected Q_SLOTS:
 
     void onStackedWidgetWidgetRemoved(int index);
 
-    void onTabPageTitleChanged(QString title);
+    void onTabPageTitleChanged();
     void onTabPageStatusChanged(int type, QString statusText);
     void onTabPageSortFilterChanged();
 

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -392,8 +392,8 @@ void TabPage::onFilesAdded(Fm::FileInfoList files) {
 void TabPage::onFolderFinishLoading() {
     auto fi = folder_->info();
     if(fi) { // if loading of the folder fails, it's possible that we don't have FmFileInfo.
-        setWindowTitle(fi->displayName());
-        Q_EMIT titleChanged(fi->displayName());
+        title_ = fi->displayName();
+        Q_EMIT titleChanged();
     }
 
     folder_->queryFilesystemInfo(); // FIXME: is this needed?
@@ -591,7 +591,9 @@ void TabPage::chdir(Fm::FilePath newPath, bool addHistory) {
         freeFolder();
     }
 
-    Q_EMIT titleChanged(QString::fromUtf8(newPath.baseName().get()));  // FIXME: display name
+    // set title as with path button (will change if the new folder is loaded)
+    title_ = QString::fromUtf8(newPath.baseName().get());
+    Q_EMIT titleChanged();
 
     folder_ = Fm::Folder::fromPath(newPath);
     if(addHistory) {

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -199,6 +199,10 @@ public:
 
     void reload();
 
+    QString title() const {
+        return title_;
+    }
+
     QString statusText(StatusTextType type = StatusTextNormal) const {
         return statusText_[type];
     }
@@ -268,7 +272,7 @@ public:
 
 Q_SIGNALS:
     void statusChanged(int type, QString statusText);
-    void titleChanged(QString title);
+    void titleChanged();
     void sortFilterChanged();
     void forwardRequested();
     void backwardRequested();
@@ -307,6 +311,7 @@ private:
     ProxyFilter* proxyFilter_;
     QVBoxLayout* verticalLayout;
     std::shared_ptr<Fm::Folder> folder_;
+    QString title_;
     QString statusText_[StatusTextNum];
     Fm::BrowseHistory history_; // browsing history
     Fm::FilePath lastFolderPath_; // last browsed folder


### PR DESCRIPTION
This patch prevents ampersands in file names from being interpreted as mnemonics in tab texts and shows them completely.

Also, because most styles can't handle newlines correctly in tab texts, newlines are replaced by spaces.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1211