### PR TITLE
Added an option to open desktop folders in default file manager

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -207,6 +207,17 @@ A space is also reserved for 3 lines of text.</string>
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="defaultFileManager">
+         <property name="toolTip">
+          <string>By default, desktop folders will be opened in PCManFM-Qt if they
+are left clicked, even when it is not the default file manager.</string>
+         </property>
+         <property name="text">
+          <string>Open desktop folders in default file manager by left clicking</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -129,6 +129,8 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
   ui.vMargin->setValue(settings.desktopCellMargins().height());
   connect(ui.lockMargins, &QAbstractButton::clicked, this, &DesktopPreferencesDialog::lockMargins);
 
+  ui.defaultFileManager->setChecked(settings.openWithDefaultFileManager());
+
   resize(sizeHint()); // show it compact
 }
 
@@ -204,6 +206,8 @@ void DesktopPreferencesDialog::applySettings()
   settings.setDesktopShortcuts(ds);
 
   settings.setDesktopCellMargins(QSize(ui.hMargin->value(), ui.vMargin->value()));
+
+  settings.setOpenWithDefaultFileManager(ui.defaultFileManager->isChecked());
 
   settings.save();
 }

--- a/pcmanfm/launcher.h
+++ b/pcmanfm/launcher.h
@@ -40,12 +40,20 @@ public:
         openInNewTab_ = true;
     }
 
+    bool openWithDefaultFileManager() const {
+        return openWithDefaultFileManager_;
+    }
+    void setOpenWithDefaultFileManager(bool open) {
+        openWithDefaultFileManager_ = open;
+    }
+
 protected:
     bool openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folderInfos, Fm::GErrorPtr& err) override;
 
 private:
     MainWindow* mainWindow_;
     bool openInNewTab_;
+    bool openWithDefaultFileManager_;
 };
 
 }

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -130,6 +130,7 @@ Settings::Settings():
     thumbnailIconSize_(128),
     folderViewCellMargins_(QSize(3, 3)),
     desktopCellMargins_(QSize(3, 1)),
+    openWithDefaultFileManager_(false),
     searchNameCaseInsensitive_(false),
     searchContentCaseInsensitive_(false),
     searchNameRegexp_(true),
@@ -260,6 +261,7 @@ bool Settings::loadFile(QString filePath) {
 
     desktopCellMargins_ = (settings.value(QStringLiteral("DesktopCellMargins"), QSize(3, 1)).toSize()
                            .expandedTo(QSize(0, 0))).boundedTo(QSize(48, 48));
+    openWithDefaultFileManager_ = settings.value(QStringLiteral("OpenWithDefaultFileManager"), false).toBool();
     settings.endGroup();
 
     settings.beginGroup(QStringLiteral("Volume"));
@@ -398,6 +400,7 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue(QStringLiteral("SortFolderFirst"), desktopSortFolderFirst_);
     settings.setValue(QStringLiteral("SortHiddenLast"), desktopSortHiddenLast_);
     settings.setValue(QStringLiteral("DesktopCellMargins"), desktopCellMargins_);
+    settings.setValue(QStringLiteral("OpenWithDefaultFileManager"), openWithDefaultFileManager_);
     settings.endGroup();
 
     settings.beginGroup(QStringLiteral("Volume"));

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -774,6 +774,13 @@ public:
         desktopCellMargins_ = size;
     }
 
+    bool openWithDefaultFileManager() const {
+        return openWithDefaultFileManager_;
+    }
+
+    void setOpenWithDefaultFileManager(bool open) {
+        openWithDefaultFileManager_ = open;
+    }
 
     bool showThumbnails() {
         return showThumbnails_;
@@ -1061,6 +1068,8 @@ private:
 
     QSize folderViewCellMargins_;
     QSize desktopCellMargins_;
+
+    bool openWithDefaultFileManager_;
 
     // search settings
     bool searchNameCaseInsensitive_;


### PR DESCRIPTION
The option is in the first tab of Desktop Preferences and is unchecked by default. It has effect when desktop folders are launched in the usual way, i.e., by left clicking, and the text label is explicit about that. Middle/right clicking triggers the default behavior.

NOTE: For user convenience, the home shortcut will also be opened by the default file manager if the option is checked but the other shortcuts are always opened by pcmanfm-qt because other file managers may not be able to handle them.

Closes https://github.com/lxqt/lxqt/issues/1823