### PR TITLE
Natural keyboard navigation on Desktop

### DIFF
--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -158,6 +158,8 @@ private:
 
     QImage getWallpaperImage() const;
 
+    QModelIndex navigateWithKey(int key, Qt::KeyboardModifiers modifiers, const QModelIndex& start = QModelIndex());
+
     QModelIndex indexForPos(bool* isTrash, const QPoint& pos, const QRect& workArea, const QSize& grid) const;
 
 private:


### PR DESCRIPTION
With this patch, the arrow keys follow the visible arrangement of items, from top to bottom and right to left. `Home`, `End`, PgDn` and `PgUp` are covered too.

Also, `Shift` adds to the selection and `Ctrl` changes the current item without changing the selection.

Closes https://github.com/lxqt/pcmanfm-qt/issues/577