### PR TITLE
Don't put a non-directory path into search dialog

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -1999,16 +1999,18 @@ void MainWindow::on_actionOpenAsRoot_triggered() {
 
 void MainWindow::on_actionFindFiles_triggered() {
     Application* app = static_cast<Application*>(qApp);
-    auto selectedPaths = currentPage()->selectedFilePaths();
+    const auto files = currentPage()->selectedFiles();
     QStringList paths;
-    if(!selectedPaths.empty()) {
-        for(auto& path: selectedPaths) {
+    if(!files.empty()) {
+        for(const auto& file: files) {
             // FIXME: is it ok to use display name here?
             // This might be broken on filesystems with non-UTF-8 filenames.
-            paths.append(QString::fromUtf8(path.displayName().get()));
+            if(file->isDir()) {
+                paths.append(QString::fromUtf8(file->path().displayName().get()));
+            }
         }
     }
-    else {
+    if(paths.isEmpty()) {
         paths.append(currentPage()->pathName());
     }
     app->findFiles(paths);


### PR DESCRIPTION
Use the parent folder if the selection doesn't contain a directory.

Fixes https://github.com/lxqt/pcmanfm-qt/issues/1237