### PR TITLE
Don't show busy cursor before folder loading

### DIFF
--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -651,9 +651,6 @@ void TabPage::chdir(Fm::FilePath newPath, bool addHistory) {
         onFolderFinishLoading();
         onFolderFsInfo();
     }
-    else {
-        onFolderStartLoading();
-    }
 }
 
 void TabPage::selectAll() {


### PR DESCRIPTION
Closes https://github.com/lxqt/pcmanfm-qt/issues/1263