### PR TITLE
Changed a label and added a tooltip to Preferences

### DIFF
--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -130,7 +130,7 @@
             <item row="3" column="0">
              <widget class="QLabel" name="label_2">
               <property name="text">
-               <string>Bookmarks:</string>
+               <string>Bookmarks menu:</string>
               </property>
              </widget>
             </item>
@@ -209,6 +209,9 @@
             </item>
             <item>
              <widget class="QCheckBox" name="selectNewFiles">
+              <property name="toolTip">
+               <string>Renamed files will also be selected</string>
+              </property>
               <property name="text">
                <string>Select newly created files</string>
               </property>


### PR DESCRIPTION
`Bookmarks:` is changed to `Bookmarks menu:` because it isn't about bookmarks on the side-pane.

Also added a tooltip for "Select newly created files" to inform the user that it also works with renamed files.