### PR TITLE
Added "invert selection" shortcut

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -617,6 +617,9 @@
    <property name="text">
     <string>&amp;Invert Selection</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+A</string>
+   </property>
   </action>
   <action name="actionDelete">
    <property name="icon">


### PR DESCRIPTION
There is no easy way to unselect after ctrl+A using the  keyboard, I was missing that.
ctrl+shift+a inverts selection.
Could be also another instead of this one.