### PR TITLE
Always focus visible view on opening new tab

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -667,11 +667,14 @@ int MainWindow::addTabWithPage(TabPage* page, ViewFrame* viewFrame, Fm::FilePath
 
     Settings& settings = static_cast<Application*>(qApp)->settings();
     if(settings.switchToNewTab()) {
-        viewFrame->getTabBar()->setCurrentIndex(index);
+        viewFrame->getTabBar()->setCurrentIndex(index); // also focuses the view
         if (isMinimized()) {
             setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
             show();
         }
+    }
+    else if(TabPage* tabPage = currentPage()) {
+        tabPage->folderView()->childView()->setFocus();
     }
     if(!settings.alwaysShowTabs()) {
         viewFrame->getTabBar()->setVisible(viewFrame->getTabBar()->count() > 1);


### PR DESCRIPTION
Previously, when the option "Switch to newly opened tab" was checked, the visible view got focused automatically but, *without that option*, it might remain unfocused (e.g., when the new tab was opened by middle clicking a side-pane bookmark).

This patch guarantees that the visible view is always focused after opening new tabs.