### PR TITLE
Completed the support for creation time

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -104,6 +104,7 @@
      </property>
      <addaction name="actionByFileName"/>
      <addaction name="actionByMTime"/>
+     <addaction name="actionByCrTime"/>
      <addaction name="actionByDTime"/>
      <addaction name="actionByFileSize"/>
      <addaction name="actionByFileType"/>
@@ -513,6 +514,14 @@
    </property>
    <property name="text">
     <string>By &amp;Modification Time</string>
+   </property>
+  </action>
+  <action name="actionByCrTime">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>By C&amp;reation Time</string>
    </property>
   </action>
   <action name="actionByDTime">

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -223,6 +223,7 @@ MainWindow::MainWindow(Fm::FilePath path):
     group->setExclusive(true);
     group->addAction(ui.actionByFileName);
     group->addAction(ui.actionByMTime);
+    group->addAction(ui.actionByCrTime);
     group->addAction(ui.actionByDTime);
     group->addAction(ui.actionByFileSize);
     group->addAction(ui.actionByFileType);
@@ -880,6 +881,10 @@ void MainWindow::on_actionByMTime_triggered(bool /*checked*/) {
     currentPage()->sort(Fm::FolderModel::ColumnFileMTime, currentPage()->sortOrder());
 }
 
+void MainWindow::on_actionByCrTime_triggered(bool /*checked*/) {
+    currentPage()->sort(Fm::FolderModel::ColumnFileCrTime, currentPage()->sortOrder());
+}
+
 void MainWindow::on_actionByDTime_triggered(bool /*checked*/) {
     currentPage()->sort(Fm::FolderModel::ColumnFileDTime, currentPage()->sortOrder());
 }
@@ -1296,6 +1301,7 @@ void MainWindow::updateViewMenuForCurrentPage() {
         }
         sortActions[Fm::FolderModel::ColumnFileName] = ui.actionByFileName;
         sortActions[Fm::FolderModel::ColumnFileMTime] = ui.actionByMTime;
+        sortActions[Fm::FolderModel::ColumnFileCrTime] = ui.actionByCrTime;
         sortActions[Fm::FolderModel::ColumnFileDTime] = ui.actionByDTime;
         sortActions[Fm::FolderModel::ColumnFileSize] = ui.actionByFileSize;
         sortActions[Fm::FolderModel::ColumnFileType] = ui.actionByFileType;

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -150,6 +150,7 @@ protected Q_SLOTS:
 
     void on_actionByFileName_triggered(bool checked);
     void on_actionByMTime_triggered(bool checked);
+    void on_actionByCrTime_triggered(bool checked);
     void on_actionByDTime_triggered(bool checked);
     void on_actionByOwner_triggered(bool checked);
     void on_actionByGroup_triggered(bool checked);

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -605,6 +605,9 @@ static const char* sortColumnToString(Fm::FolderModel::ColumnId value) {
     case Fm::FolderModel::ColumnFileMTime:
         ret = "mtime";
         break;
+    case Fm::FolderModel::ColumnFileCrTime:
+        ret = "crtime";
+        break;
     case Fm::FolderModel::ColumnFileDTime:
         ret = "dtime";
         break;
@@ -631,6 +634,9 @@ static Fm::FolderModel::ColumnId sortColumnFromString(const QString str) {
     }
     else if(str == QLatin1String("mtime")) {
         ret = Fm::FolderModel::ColumnFileMTime;
+    }
+    else if(str == QLatin1String("crtime")) {
+        ret = Fm::FolderModel::ColumnFileCrTime;
     }
     else if(str == QLatin1String("dtime")) {
         ret = Fm::FolderModel::ColumnFileDTime;


### PR DESCRIPTION
Follows and depends on https://github.com/lxqt/libfm-qt/pull/627

NOTE: The settings for the hidden columns of the detailed list mode may change (because a new column is added). If you have hidden some columns, you might need to change them after this patch.