### PR TITLE
Handle GVFS' Admin separately and appropriately

### DIFF
--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -304,6 +304,8 @@ private:
     void onFolderUnmount();
     void onFolderContentChanged();
 
+    bool canOpenAdmin();
+
 private:
     View* folderView_;
     Fm::CachedFolderModel* folderModel_;


### PR DESCRIPTION
Since Admin is peculiar (e.g., its mount isn't visible and it asks for the password after being mounted), it's treated separately for preventing another Polkit prompt after the first one is cancelled.

The patch mostly consists of long comments because, although its code is very simple, the logic behind it is not.

I also found and worked around a bug in the GVFS admin backend, which could cause an infinite loop in the old code (without the current patch and in a very rare case). Unfortunately, our old code can still be vulnerable to upstream bugs but that's a separate topic.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1306