### PR TITLE
Added an option for max. file size with external thumbnailers

### DIFF
--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -122,14 +122,14 @@
               <property name="enabled">
                <bool>false</bool>
               </property>
+              <property name="toolTip">
+               <string>Set to zero to disable auto-selection.</string>
+              </property>
               <property name="suffix">
                <string> sec</string>
               </property>
               <property name="singleStep">
                <double>0.100000000000000</double>
-              </property>
-              <property name="toolTip">
-               <string>Set to zero to disable auto-selection.</string>
               </property>
              </widget>
             </item>
@@ -617,6 +617,11 @@ only if there are more than one tab.</string>
             </item>
             <item row="2" column="0">
              <widget class="QLabel" name="label_10">
+              <property name="toolTip">
+               <string>The built-in thumbnailer makes thumbnails of images that are supported by Qt.
+
+Usually, most image types are supported. The default size limit is 4 MiB.</string>
+              </property>
               <property name="text">
                <string>Image size limit for built-in thumbnailer:</string>
               </property>
@@ -624,6 +629,11 @@ only if there are more than one tab.</string>
             </item>
             <item row="2" column="1">
              <widget class="QDoubleSpinBox" name="maxThumbnailFileSize">
+              <property name="toolTip">
+               <string>The built-in thumbnailer makes thumbnails of images that are supported by Qt.
+
+Usually, most image types are supported. The default size limit is 4 MiB.</string>
+              </property>
               <property name="suffix">
                <string> MiB</string>
               </property>
@@ -640,6 +650,11 @@ only if there are more than one tab.</string>
             </item>
             <item row="3" column="0">
              <widget class="QLabel" name="label_17">
+              <property name="toolTip">
+               <string>If existing, external thumbnailers are used for videos, PDF documents, etc.
+
+A value of -1 means that there is no limit for the file size (the default).</string>
+              </property>
               <property name="text">
                <string>File size limit for external thumbnailers:</string>
               </property>
@@ -647,6 +662,11 @@ only if there are more than one tab.</string>
             </item>
             <item row="3" column="1">
              <widget class="QSpinBox" name="maxExternalThumbnailFileSize">
+              <property name="toolTip">
+               <string>If existing, external thumbnailers are used for videos, PDF documents, etc.
+
+A value of -1 means that there is no limit for the file size (the default).</string>
+              </property>
               <property name="specialValueText">
                <string>No limit</string>
               </property>

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -598,20 +598,13 @@ only if there are more than one tab.</string>
             <string>Thumbnail</string>
            </property>
            <layout class="QFormLayout" name="formLayout_3">
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_10">
+            <item row="0" column="0" colspan="2">
+             <widget class="QCheckBox" name="showThumbnails">
+              <property name="toolTip">
+               <string>Needs ffmpegthumbnailer</string>
+              </property>
               <property name="text">
-               <string>Do not generate thumbnails for image files exceeding this size:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QSpinBox" name="maxThumbnailFileSize">
-              <property name="suffix">
-               <string> KB</string>
-              </property>
-              <property name="maximum">
-               <number>1048576</number>
+               <string>Show thumbnails of files</string>
               </property>
              </widget>
             </item>
@@ -622,13 +615,52 @@ only if there are more than one tab.</string>
               </property>
              </widget>
             </item>
-            <item row="0" column="0" colspan="2">
-             <widget class="QCheckBox" name="showThumbnails">
-              <property name="toolTip">
-               <string>Needs ffmpegthumbnailer</string>
-              </property>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_10">
               <property name="text">
-               <string>Show thumbnails of files</string>
+               <string>Image size limit for built-in thumbnailer:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QDoubleSpinBox" name="maxThumbnailFileSize">
+              <property name="suffix">
+               <string> MiB</string>
+              </property>
+              <property name="decimals">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <double>1024.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>4.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_17">
+              <property name="text">
+               <string>File size limit for external thumbnailers:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QSpinBox" name="maxExternalThumbnailFileSize">
+              <property name="specialValueText">
+               <string>No limit</string>
+              </property>
+              <property name="suffix">
+               <string> MiB</string>
+              </property>
+              <property name="minimum">
+               <number>-1</number>
+              </property>
+              <property name="maximum">
+               <number>2048</number>
+              </property>
+              <property name="value">
+               <number>-1</number>
               </property>
              </widget>
             </item>

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -236,7 +236,12 @@ void PreferencesDialog::initBehaviorPage(Settings& settings) {
 void PreferencesDialog::initThumbnailPage(Settings& settings) {
     ui.showThumbnails->setChecked(settings.showThumbnails());
     ui.thumbnailLocal->setChecked(settings.thumbnailLocalFilesOnly());
-    ui.maxThumbnailFileSize->setValue(settings.maxThumbnailFileSize());
+
+    // the max. thumbnail size spinboxes are in MiB
+    double m = settings.maxThumbnailFileSize();
+    ui.maxThumbnailFileSize->setValue(qBound(0.0, m / 1024, 1024.0));
+    int m1 = settings.maxExternalThumbnailFileSize();
+    ui.maxExternalThumbnailFileSize->setValue(m1 < 0 ? -1 : qMin(m1 / 1024, 2048));
 }
 
 void PreferencesDialog::initVolumePage(Settings& settings) {
@@ -349,7 +354,10 @@ void PreferencesDialog::applyBehaviorPage(Settings& settings) {
 void PreferencesDialog::applyThumbnailPage(Settings& settings) {
     settings.setShowThumbnails(ui.showThumbnails->isChecked());
     settings.setThumbnailLocalFilesOnly(ui.thumbnailLocal->isChecked());
-    settings.setMaxThumbnailFileSize(ui.maxThumbnailFileSize->value());
+    // the max. thumbnail size spinboxes are in MiB
+    settings.setMaxThumbnailFileSize(qRound(ui.maxThumbnailFileSize->value() * 1024));
+    int m = ui.maxExternalThumbnailFileSize->value();
+    settings.setMaxExternalThumbnailFileSize(m < 0 ? -1 : m * 1024);
 }
 
 void PreferencesDialog::applyVolumePage(Settings& settings) {

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -223,8 +223,6 @@ bool Settings::loadFile(QString filePath) {
     confirmTrash_ = settings.value(QStringLiteral("ConfirmTrash"), false).toBool();
     setQuickExec(settings.value(QStringLiteral("QuickExec"), false).toBool());
     selectNewFiles_ = settings.value(QStringLiteral("SelectNewFiles"), false).toBool();
-    // bool thumbnailLocal_;
-    // bool thumbnailMax;
     settings.endGroup();
 
     settings.beginGroup(QStringLiteral("Desktop"));
@@ -272,6 +270,7 @@ bool Settings::loadFile(QString filePath) {
     settings.beginGroup(QStringLiteral("Thumbnail"));
     showThumbnails_ = settings.value(QStringLiteral("ShowThumbnails"), true).toBool();
     setMaxThumbnailFileSize(settings.value(QStringLiteral("MaxThumbnailFileSize"), 4096).toInt());
+    setMaxExternalThumbnailFileSize(settings.value(QStringLiteral("MaxExternalThumbnailFileSize"), -1).toInt());
     setThumbnailLocalFilesOnly(settings.value(QStringLiteral("ThumbnailLocalFilesOnly"), true).toBool());
     settings.endGroup();
 
@@ -370,8 +369,6 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue(QStringLiteral("ConfirmTrash"), confirmTrash_);
     settings.setValue(QStringLiteral("QuickExec"), quickExec_);
     settings.setValue(QStringLiteral("SelectNewFiles"), selectNewFiles_);
-    // bool thumbnailLocal_;
-    // bool thumbnailMax;
     settings.endGroup();
 
     settings.beginGroup(QStringLiteral("Desktop"));
@@ -411,6 +408,7 @@ bool Settings::saveFile(QString filePath) {
     settings.beginGroup(QStringLiteral("Thumbnail"));
     settings.setValue(QStringLiteral("ShowThumbnails"), showThumbnails_);
     settings.setValue(QStringLiteral("MaxThumbnailFileSize"), maxThumbnailFileSize());
+    settings.setValue(QStringLiteral("MaxExternalThumbnailFileSize"), maxExternalThumbnailFileSize());
     settings.setValue(QStringLiteral("ThumbnailLocalFilesOnly"), thumbnailLocalFilesOnly());
     settings.endGroup();
 

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -727,9 +727,6 @@ public:
         selectNewFiles_ = value;
     }
 
-    // bool thumbnailLocal_;
-    // bool thumbnailMax;
-
     int bigIconSize() const {
         return bigIconSize_;
     }
@@ -804,6 +801,14 @@ public:
 
     void setMaxThumbnailFileSize(int size) {
         Fm::ThumbnailJob::setMaxThumbnailFileSize(size);
+    }
+
+    int maxExternalThumbnailFileSize() const {
+        return Fm::ThumbnailJob::maxExternalThumbnailFileSize();
+    }
+
+    void setMaxExternalThumbnailFileSize(int size) {
+        Fm::ThumbnailJob::setMaxExternalThumbnailFileSize(size);
     }
 
     void setThumbnailIconSize(int thumbnailIconSize) {


### PR DESCRIPTION
Follows and depends on https://github.com/lxqt/libfm-qt/pull/644

The external thumbnailers shouldn't follow the size limit of our built-in image thumbnailer. We allocate an amount of memeory equal to the file size when making internal thumbnails of images but an external thumbnailer can easily create the thumbnail of a 1-GiB video. In other words, images and videos shouldn't have the same size limit.

Moreover, this patch is backward-compatible: users won't see a difference with external thumbnails (of videos, PDF,…) and the behavior of internal thumbnails will be mostly unchanged.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1316