### PR TITLE
Updating old PCManFM entries

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -165,10 +165,10 @@ bool Application::parseCommandLineArgs() {
     QCommandLineOption profileOption(QStringList() << QStringLiteral("p") << QStringLiteral("profile"), tr("Name of configuration profile"), tr("PROFILE"));
     parser.addOption(profileOption);
 
-    QCommandLineOption daemonOption(QStringList() << QStringLiteral("d") << QStringLiteral("daemon-mode"), tr("Run PCManFM as a daemon"));
+    QCommandLineOption daemonOption(QStringList() << QStringLiteral("d") << QStringLiteral("daemon-mode"), tr("Run PCManFM-Qt as a daemon"));
     parser.addOption(daemonOption);
 
-    QCommandLineOption quitOption(QStringList() << QStringLiteral("q") << QStringLiteral("quit"), tr("Quit PCManFM"));
+    QCommandLineOption quitOption(QStringList() << QStringLiteral("q") << QStringLiteral("quit"), tr("Quit PCManFM-Qt"));
     parser.addOption(quitOption);
 
     QCommandLineOption desktopOption(QStringLiteral("desktop"), tr("Launch desktop manager"));


### PR DESCRIPTION
While translating I spotted two lines that still had PCManFM without "-qt".
I think this behaviour was not intentional, but if it was, correct me.