### PR TITLE
Update old entries of PCManFM to "-qt"

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -165,10 +165,10 @@ bool Application::parseCommandLineArgs() {
     QCommandLineOption profileOption(QStringList() << QStringLiteral("p") << QStringLiteral("profile"), tr("Name of configuration profile"), tr("PROFILE"));
     parser.addOption(profileOption);
 
-    QCommandLineOption daemonOption(QStringList() << QStringLiteral("d") << QStringLiteral("daemon-mode"), tr("Run PCManFM as a daemon"));
+    QCommandLineOption daemonOption(QStringList() << QStringLiteral("d") << QStringLiteral("daemon-mode"), tr("Run PCManFM-Qt as a daemon"));
     parser.addOption(daemonOption);
 
-    QCommandLineOption quitOption(QStringList() << QStringLiteral("q") << QStringLiteral("quit"), tr("Quit PCManFM"));
+    QCommandLineOption quitOption(QStringList() << QStringLiteral("q") << QStringLiteral("quit"), tr("Quit PCManFM-Qt"));
     parser.addOption(quitOption);
 
     QCommandLineOption desktopOption(QStringLiteral("desktop"), tr("Launch desktop manager"));

--- a/pcmanfm/translations/pcmanfm-qt.ts
+++ b/pcmanfm/translations/pcmanfm-qt.ts
@@ -1319,12 +1319,12 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../application.cpp" line="168"/>
-        <source>Run PCManFM-Qt as a daemon</source>
+        <source>Run PCManFM as a daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application.cpp" line="171"/>
-        <source>Quit PCManFM-Qt</source>
+        <source>Quit PCManFM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt.ts
+++ b/pcmanfm/translations/pcmanfm-qt.ts
@@ -1319,12 +1319,12 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../application.cpp" line="168"/>
-        <source>Run PCManFM as a daemon</source>
+        <source>Run PCManFM-Qt as a daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../application.cpp" line="171"/>
-        <source>Quit PCManFM</source>
+        <source>Quit PCManFM-Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
While translating I spotted two lines that still had PCManFM without "-qt".
I think this behaviour was not intentional, but if it was, correct me.