### PR TITLE
Added an action to remove settings of nonexistent folders

### DIFF
--- a/pcmanfm/application.h
+++ b/pcmanfm/application.h
@@ -96,6 +96,8 @@ public:
         return profileName_;
     }
 
+    void cleanPerFolderConfig();
+
 protected Q_SLOTS:
     void onAboutToQuit();
     void onSigtermNotified();

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -155,7 +155,9 @@
      </property>
      <addaction name="actionPreserveView"/>
      <addaction name="actionPreserveViewRecursive"/>
+     <addaction name="separator"/>
      <addaction name="actionGoToCustomizedViewSource"/>
+     <addaction name="actionCleanPerFolderConfig"/>
     </widget>
     <addaction name="actionReload"/>
     <addaction name="separator"/>
@@ -949,6 +951,11 @@
   <action name="actionGoToCustomizedViewSource">
    <property name="text">
     <string>Go to Source of Inherited Settings</string>
+   </property>
+  </action>
+  <action name="actionCleanPerFolderConfig">
+   <property name="text">
+    <string>Remove Settings of Nonexistent Folders</string>
    </property>
   </action>
  </widget>

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -2202,4 +2202,16 @@ void MainWindow::onShortcutJumpToTab() {
     }
 }
 
+void MainWindow::on_actionCleanPerFolderConfig_triggered() {
+    QMessageBox::StandardButton r = QMessageBox::question(this,
+                                    tr("Cleaning Folder Settings"),
+                                    tr("Do you want to remove settings of nonexistent folders?\nThey might be useful if those folders are created again."),
+                                    QMessageBox::Yes | QMessageBox::No,
+                                    QMessageBox::No);
+    if(r == QMessageBox::Yes) {
+        Application* app = static_cast<Application*>(qApp);
+        app->cleanPerFolderConfig();
+    }
+}
+
 }

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -234,6 +234,8 @@ protected Q_SLOTS:
 
     void onSettingHiddenPlace(const QString& str, bool hide);
 
+    void on_actionCleanPerFolderConfig_triggered();
+
 protected:
     bool event(QEvent* event) override;
     void changeEvent(QEvent* event) override;


### PR DESCRIPTION
A prompt dialog is shown that tells the user why those settings might be useful later.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1382