### PR TITLE
Don't save/read custom positions of desktop items constantly

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -372,6 +372,11 @@ void Application::onUserDirsChanged() {
 
 void Application::onAboutToQuit() {
     qDebug("aboutToQuit");
+    // save custom positions of desktop items
+    if(!desktopWindows_.isEmpty()) {
+        desktopWindows_.first()->saveItemPositions();
+    }
+
     settings_.save();
 }
 

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -79,6 +79,8 @@ public:
 
     void queueRelayout(int delay = 0);
 
+    void saveItemPositions();
+
     int screenNum() const {
         return screenNum_;
     }
@@ -94,7 +96,8 @@ protected:
     virtual void onFileClicked(int type, const std::shared_ptr<const Fm::FileInfo>& fileInfo) override;
 
     void loadItemPositions();
-    void saveItemPositions();
+    void retrieveCustomPos();
+    void storeCustomPos();
 
     QImage loadWallpaperFile(QSize requiredSize);
 
@@ -183,7 +186,8 @@ private:
     bool desktopHideItems_;
 
     int screenNum_;
-    std::unordered_map<std::string, QPoint> customItemPos_;
+    std::unordered_map<std::string, QPoint> customItemPos_; // real custom positions
+    std::unordered_map<std::string, QPoint> customPosStorage_; // savable custom positions
     QTimer* relayoutTimer_;
     QTimer* selectionTimer_;
 


### PR DESCRIPTION
Previously, the custom positions of desktop items were saved to disk with any DND, addition or removal of sticky items. They were also read from disk with every update of the desktop layout.

This patch reads the config file at startup. keeps track of custom positions in the memory, and saves them to the config file only when the app is about to exit.

It will be especially useful when an option is added for making all desktop items sticky, although avoiding too much I/O is always good.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1394