### PR TITLE
Disable tab DND under Wayland

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -87,6 +87,9 @@ Application::Application(int& argc, char** argv):
     userDirsWatcher_(nullptr),
     lxqtRunning_(false) {
 
+    // mainly used to disable tab DND outside X11 because Wayland has problem with QDrag
+    isX11_ = QGuiApplication::platformName() == QStringLiteral("xcb");
+
     argc_ = argc;
     argv_ = argv;
 

--- a/pcmanfm/application.h
+++ b/pcmanfm/application.h
@@ -72,6 +72,10 @@ public:
         return libFm_;
     }
 
+    bool isX11() const {
+      return isX11_;
+    }
+
     // public interface exported via dbus
     void launchFiles(QString cwd, QStringList paths, bool inNewWindow, bool reopenLastTabs);
     void setWallpaper(QString path, QString modeString);
@@ -149,6 +153,8 @@ private:
     QString userDirsFile_;
     QString userDesktopFolder_;
     bool lxqtRunning_;
+
+    bool isX11_;
 
     int argc_;
     char** argv_;

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -257,7 +257,7 @@ private:
     void addViewFrame(const Fm::FilePath& path);
     ViewFrame* viewFrameForTabPage(TabPage* page);
     int addTabWithPage(TabPage* page, ViewFrame* viewFrame, Fm::FilePath path = Fm::FilePath());
-    void dropTab();
+    void dropTab(QObject* source);
     void setTabIcon(TabPage* tabPage);
 
 private:

--- a/pcmanfm/tabbar.cpp
+++ b/pcmanfm/tabbar.cpp
@@ -35,11 +35,13 @@ TabBar::TabBar(QWidget *parent):
 }
 
 void TabBar::mousePressEvent(QMouseEvent *event) {
-    QTabBar::mousePressEvent (event);
-    if(detachable_){
-        if(event->button() == Qt::LeftButton
-        && tabAt(event->pos()) > -1) {
+    QTabBar::mousePressEvent(event);
+    if(detachable_) {
+        if(event->button() == Qt::LeftButton && tabAt(event->pos()) > -1) {
             dragStartPosition_ = event->pos();
+        }
+        else {
+            dragStartPosition_ = QPoint();
         }
         dragStarted_ = false;
     }
@@ -52,7 +54,7 @@ void TabBar::mouseMoveEvent(QMouseEvent *event)
         return;
     }
 
-    if(!dragStartPosition_.isNull()
+    if(!dragStarted_ && !dragStartPosition_.isNull()
        && (event->pos() - dragStartPosition_).manhattanLength() >= QApplication::startDragDistance()) {
         dragStarted_ = true;
     }


### PR DESCRIPTION
Wayland has a serious problem with `QDrag`, that can result in a crash. Since Wayland doesn't announce window positions, I don't think it'll be fixed (soon). Therefore, this patch disables tab DND outside X11.

The patch also cleans up the code of tab DND by using the drag source, instead of assuming that it's always the last active window. Some rare and hidden issues are fixed too.