### PR TITLE
close floating windows when pcmanfm-qt primary instance quits

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -44,6 +44,7 @@
 #include <libfm-qt/core/terminal.h>
 #include <libfm-qt/core/bookmarks.h>
 #include <libfm-qt/core/folderconfig.h>
+#include <libfm-qt/utilities.h>
 
 #include "applicationadaptor.h"
 #include "preferencesdialog.h"

--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -375,6 +375,8 @@ void Application::onUserDirsChanged() {
 
 void Application::onAboutToQuit() {
     qDebug("aboutToQuit");
+    Fm::closeFloatingWindows();
+
     // save custom positions of desktop items
     if(!desktopWindows_.isEmpty()) {
         desktopWindows_.first()->saveItemPositions();


### PR DESCRIPTION
This PR depends on [libfm-qt #728](https://github.com/lxqt/libfm-qt/pull/728) and closes potential floating windows pointers before the pcmanfm-qt primary instance quits.