### PR TITLE
Added a nullity check

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -949,7 +949,7 @@ void DesktopWindow::onFileClicked(int type, const std::shared_ptr<const Fm::File
     }
     else {
         // special right-click menus for our desktop shortcuts
-        if(fileInfo && fileInfo->isDesktopEntry() && type == Fm::FolderView::ContextMenuClick) {
+        if(fileInfo && fileInfo->isDesktopEntry() && type == Fm::FolderView::ContextMenuClick && hasSelection()) {
             Settings& settings = static_cast<Application* >(qApp)->settings();
             const QStringList ds = settings.desktopShortcuts();
             if(!ds.isEmpty()) {

--- a/pcmanfm/view.cpp
+++ b/pcmanfm/view.cpp
@@ -41,7 +41,7 @@ View::~View() = default;
 
 void View::onFileClicked(int type, const std::shared_ptr<const Fm::FileInfo>& fileInfo) {
     if(type == MiddleClick) {
-        if(fileInfo->isDir()) {
+        if(fileInfo && fileInfo->isDir()) {
             // fileInfo->path() shouldn't be used directly because
             // it won't work in places like computer:/// or network:///
             Fm::FileInfoList files;


### PR DESCRIPTION
Only by chance, its absence had no effect.

Also, the existence of a selection is checked on showing the context menu of a desktop shortcut. After a recent fix to `libfm-qt` (https://github.com/lxqt/libfm-qt/commit/bf8b06457ef27eb8db498631bcb3c04d42d763cf), its absence had a very small side effect.