### PR TITLE
Never close file operation dialog on closing window

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -1720,7 +1720,7 @@ void MainWindow::on_actionCut_triggered() {
 }
 
 void MainWindow::on_actionPaste_triggered() {
-    pasteFilesFromClipboard(currentPage()->path(), this);
+    pasteFilesFromClipboard(currentPage()->path());
 }
 
 void MainWindow::on_actionDelete_triggered() {


### PR DESCRIPTION
It was closed when pasting from Edit menu (or by `Ctrl+V`) because the destination window was its parent.

Fixes https://github.com/lxqt/pcmanfm-qt/issues/1462