### PR TITLE
Added option to disable smooth scrolling in list and compact modes

### DIFF
--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -393,7 +393,14 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="0">
+            <item row="5" column="0" colspan="3">
+             <widget class="QCheckBox" name="noScrollPerPixel">
+              <property name="text">
+               <string>Disable smooth scrolling in list and compact modes</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="0">
              <spacer name="verticalSpacer_7">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -409,14 +416,14 @@
               </property>
              </spacer>
             </item>
-            <item row="6" column="0">
+            <item row="7" column="0">
              <widget class="QLabel" name="label_15">
               <property name="text">
                <string>Minimum item margins in icon view:</string>
               </property>
              </widget>
             </item>
-            <item row="6" column="1">
+            <item row="7" column="1">
              <widget class="QSpinBox" name="hMargin">
               <property name="toolTip">
                <string>3 px by default.</string>
@@ -432,14 +439,14 @@
               </property>
              </widget>
             </item>
-            <item row="6" column="2">
+            <item row="7" column="2">
              <widget class="QLabel" name="label_16">
               <property name="text">
                <string>x</string>
               </property>
              </widget>
             </item>
-            <item row="6" column="3">
+            <item row="7" column="3">
              <widget class="QSpinBox" name="vMargin">
               <property name="toolTip">
                <string>3 px by default.
@@ -456,14 +463,14 @@ A space is also reserved for 3 lines of text.</string>
               </property>
              </widget>
             </item>
-            <item row="6" column="4">
+            <item row="7" column="4">
              <widget class="QCheckBox" name="lockMargins">
               <property name="text">
                <string>Lock</string>
               </property>
              </widget>
             </item>
-            <item row="6" column="5">
+            <item row="7" column="5">
              <spacer name="horizontalSpacer">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -168,6 +168,7 @@ void PreferencesDialog::initDisplayPage(Settings& settings) {
     ui.showFullNames->setChecked(settings.showFullNames());
     ui.shadowHidden->setChecked(settings.shadowHidden());
     ui.noItemTooltip->setChecked(settings.noItemTooltip());
+    ui.noScrollPerPixel->setChecked(!settings.scrollPerPixel());
 
     // app restart warning
     connect(ui.showFullNames, &QAbstractButton::toggled, [this, &settings] (bool checked) {
@@ -315,6 +316,7 @@ void PreferencesDialog::applyDisplayPage(Settings& settings) {
     settings.setShowFullNames(ui.showFullNames->isChecked());
     settings.setShadowHidden(ui.shadowHidden->isChecked());
     settings.setNoItemTooltip(ui.noItemTooltip->isChecked());
+    settings.setScrollPerPixel(!ui.noScrollPerPixel->isChecked());
     settings.setFolderViewCellMargins(QSize(ui.hMargin->value(), ui.vMargin->value()));
 }
 

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -124,6 +124,7 @@ Settings::Settings():
     showFullNames_(true),
     shadowHidden_(true),
     noItemTooltip_(false),
+    scrollPerPixel_(true),
     bigIconSize_(48),
     smallIconSize_(24),
     sidePaneIconSize_(24),
@@ -290,6 +291,7 @@ bool Settings::loadFile(QString filePath) {
     showFullNames_ = settings.value(QStringLiteral("ShowFullNames"), true).toBool();
     shadowHidden_ = settings.value(QStringLiteral("ShadowHidden"), true).toBool();
     noItemTooltip_ = settings.value(QStringLiteral("NoItemTooltip"), false).toBool();
+    scrollPerPixel_ = settings.value(QStringLiteral("ScrollPerPixel"), true).toBool();
 
     // override config in libfm's FmConfig
     bigIconSize_ = toIconSize(settings.value(QStringLiteral("BigIconSize"), 48).toInt(), Big);
@@ -430,6 +432,7 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue(QStringLiteral("ShowFullNames"), showFullNames_);
     settings.setValue(QStringLiteral("ShadowHidden"), shadowHidden_);
     settings.setValue(QStringLiteral("NoItemTooltip"), noItemTooltip_);
+    settings.setValue(QStringLiteral("ScrollPerPixel"), scrollPerPixel_);
 
     // override config in libfm's FmConfig
     settings.setValue(QStringLiteral("BigIconSize"), bigIconSize_);

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -886,6 +886,14 @@ public:
         noItemTooltip_ = noTooltip;
     }
 
+    bool scrollPerPixel() const {
+        return scrollPerPixel_;
+    }
+
+    void setScrollPerPixel(bool perPixel) {
+        scrollPerPixel_ = perPixel;
+    }
+
     bool onlyUserTemplates() const {
         return onlyUserTemplates_;
     }
@@ -1087,6 +1095,7 @@ private:
     bool showFullNames_;
     bool shadowHidden_;
     bool noItemTooltip_;
+    bool scrollPerPixel_;
 
     QSet<QString> hiddenPlaces_;
 

--- a/pcmanfm/view.cpp
+++ b/pcmanfm/view.cpp
@@ -162,6 +162,8 @@ void View::updateFromSettings(Settings& settings) {
 
     setCtrlRightClick(settings.ctrlRightClick());
 
+    setScrollPerPixel(settings.scrollPerPixel());
+
     Fm::ProxyFolderModel* proxyModel = model();
     if(proxyModel) {
         proxyModel->setShowThumbnails(settings.showThumbnails());


### PR DESCRIPTION
The reason is that Qt may slow down item sorting in the list and compact modes when the number of items is huge and scrolling is done per pixel (smooth scrolling itself isn't the cause of slowdown; see https://github.com/lxqt/libfm-qt/issues/739#issuecomment-947785800). As a workaround, the user can disable per-pixel scrolling by disabling smooth scrolling in those modes, although that isn't needed in most use cases.