### PR TITLE
Added "Recent Files" to File menu

### DIFF
--- a/pcmanfm/launcher.cpp
+++ b/pcmanfm/launcher.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "launcher.h"
+#include <QFileInfo>
 #include "mainwindow.h"
 #include "application.h"
 #include <libfm-qt/core/filepath.h>
@@ -83,6 +84,30 @@ bool Launcher::openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folder
     mainWindow->activateWindow();
     openInNewTab_ = false;
     return true;
+}
+
+void Launcher::launchedFiles(const Fm::FileInfoList& files) const {
+    Application* app = static_cast<Application*>(qApp);
+    if(app->settings().getRecentFilesNumber() > 0) {
+        for(const auto& file : files) {
+            if(file->isNative() && !file->isDir()) {
+                app->settings().addRecentFile(QString::fromUtf8(file->path().localPath().get()));
+            }
+        }
+    }
+}
+void Launcher::launchedPaths(const Fm::FilePathList& paths) const {
+    Application* app = static_cast<Application*>(qApp);
+    if(app->settings().getRecentFilesNumber() > 0) {
+        for(const auto& path : paths) {
+            if(path.isNative()) {
+                auto pathStr = QString::fromUtf8(path.localPath().get());
+                if(!QFileInfo(pathStr).isDir()) { // this is fast because the path is native
+                    app->settings().addRecentFile(pathStr);
+                }
+            }
+        }
+    }
 }
 
 } //namespace PCManFM

--- a/pcmanfm/launcher.h
+++ b/pcmanfm/launcher.h
@@ -49,6 +49,8 @@ public:
 
 protected:
     bool openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folderInfos, Fm::GErrorPtr& err) override;
+    void launchedFiles(const Fm::FileInfoList& files) const override;
+    void launchedPaths(const Fm::FilePathList& paths) const override;
 
 private:
     MainWindow* mainWindow_;

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -76,6 +76,11 @@
      <addaction name="actionNewFolder"/>
      <addaction name="actionNewBlankFile"/>
     </widget>
+    <widget class="QMenu" name="menuRecentFiles">
+     <property name="title">
+      <string>Recent F&amp;iles</string>
+     </property>
+    </widget>
     <addaction name="actionNewTab"/>
     <addaction name="actionNewWin"/>
     <addaction name="separator"/>
@@ -86,6 +91,8 @@
     <addaction name="separator"/>
     <addaction name="actionCloseTab"/>
     <addaction name="actionCloseWindow"/>
+    <addaction name="separator"/>
+    <addaction name="menuRecentFiles"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
     <property name="title">
@@ -956,6 +963,14 @@
   <action name="actionCleanPerFolderConfig">
    <property name="text">
     <string>&amp;Remove Settings of Nonexistent Folders</string>
+   </property>
+  </action>
+  <action name="actionClearRecent">
+   <property name="icon">
+    <iconset theme="edit-clear"/>
+   </property>
+   <property name="text">
+    <string>&amp;Clear</string>
    </property>
   </action>
  </widget>

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -225,6 +225,9 @@ protected Q_SLOTS:
     }
     void focusPathEntry();
     void toggleMenuBar(bool checked);
+    void updateRecenMenu();
+    void clearRecentMenu();
+    void lanunchRecentFile();
     void detachTab();
 
     void onBookmarksChanged();

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -233,6 +233,43 @@
               </property>
              </widget>
             </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_3">
+              <property name="spacing">
+               <number>5</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="label_18">
+                <property name="text">
+                 <string>Number of recent files:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="recentFilesSpinBox">
+                <property name="maximum">
+                 <number>50</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::MinimumExpanding</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>1</width>
+                  <height>1</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
            </layout>
           </widget>
          </item>

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -227,6 +227,7 @@ void PreferencesDialog::initBehaviorPage(Settings& settings) {
     ui.quickExec->setChecked(settings.quickExec());
     ui.selectNewFiles->setChecked(settings.selectNewFiles());
     ui.singleWindowMode->setChecked(settings.singleWindowMode());
+    ui.recentFilesSpinBox->setValue(settings.getRecentFilesNumber());
 
     // app restart warning
     connect(ui.quickExec, &QAbstractButton::toggled, [this, &settings] (bool checked) {
@@ -351,6 +352,7 @@ void PreferencesDialog::applyBehaviorPage(Settings& settings) {
     settings.setQuickExec(ui.quickExec->isChecked());
     settings.setSelectNewFiles(ui.selectNewFiles->isChecked());
     settings.setSingleWindowMode(ui.singleWindowMode->isChecked());
+    settings.setRecentFilesNumber(ui.recentFilesSpinBox->value());
 }
 
 void PreferencesDialog::applyThumbnailPage(Settings& settings) {

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -166,9 +166,6 @@ public:
     bool load(QString profile = QStringLiteral("default"));
     bool save(QString profile = QString());
 
-    bool loadFile(QString filePath);
-    bool saveFile(QString filePath);
-
     static QString xdgUserConfigDir();
     static const QList<int> & iconSizes(IconType type);
 
@@ -1006,9 +1003,27 @@ public:
         }
     }
 
+    int getRecentFilesNumber() const {
+        return recentFilesNumber_;
+    }
+    void setRecentFilesNumber(int n);
+
+    QStringList getRecentFiles() const {
+        return recentFiles_;
+    }
+    void clearRecentFiles();
+    void addRecentFile(const QString& file);
+
+    void loadRecentFiles();
+    void saveRecentFiles();
+
 private:
+    bool loadFile(QString filePath);
+    bool saveFile(QString filePath);
+
     int toIconSize(int size, IconType type) const;
 
+private:
     QString profileName_;
     bool supportTrash_;
 
@@ -1126,6 +1141,10 @@ private:
     // detailed list columns
     QList<QVariant> customColumnWidths_;
     QList<QVariant> hiddenColumns_;
+
+    // recent files
+    int recentFilesNumber_;
+    QStringList recentFiles_;
 };
 
 }


### PR DESCRIPTION
It covers non-folder, native files that are launched (non-native files could cause trouble). The number of recent files can be set from 0 (the default) to 50.

On exiting the current session, the list of recent files is saved to a separate config file inside pcmanfm-qt's user config directory. But, if the user clears the list, the config file will be emptied immediately, for the sake of privacy.

NOTE1: This needs https://github.com/lxqt/libfm-qt/commit/6b8d5acd76e7c7eb7707257b006995b17231e72f
NOTE2: It is independent of GVFS' `recent:///`, which is useless to us.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1483