### PR TITLE
fix: The project fails to compile in the debian qt5.15 environment.

### DIFF
--- a/pcmanfm/launcher.h
+++ b/pcmanfm/launcher.h
@@ -49,8 +49,8 @@ public:
 
 protected:
     bool openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folderInfos, Fm::GErrorPtr& err) override;
-    void launchedFiles(const Fm::FileInfoList& files) const override;
-    void launchedPaths(const Fm::FilePathList& paths) const override;
+    void launchedFiles(const Fm::FileInfoList& files) const;
+    void launchedPaths(const Fm::FilePathList& paths) const;
 
 private:
     MainWindow* mainWindow_;


### PR DESCRIPTION
In launcher.h, fuction "launchedFiles()" and "launchedPaths()" are marked "override",but the parent
don't have the two function.
I also find, the two function  don't be used.
![error](https://user-images.githubusercontent.com/32997802/144163353-05faab31-008f-4c4e-9be6-5882870e8345.png)


