### PR TITLE
Fixed a rare issue in selection of new files

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -1154,13 +1154,13 @@ void DesktopWindow::onFolderFinishLoading() {
 void DesktopWindow::onFilesAdded(const Fm::FileInfoList files) {
     if(static_cast<Application*>(qApp)->settings().selectNewFiles()) {
         if(!selectionTimer_) {
-            selectFiles(files, false);
             selectionTimer_ = new QTimer (this);
             selectionTimer_->setSingleShot(true);
-            selectionTimer_->start(200);
+            if(selectFiles(files, false)) {
+                selectionTimer_->start(200);
+            }
         }
-        else {
-            selectFiles(files, selectionTimer_->isActive());
+        else if(selectFiles(files, selectionTimer_->isActive())) {
             selectionTimer_->start(200);
         }
     }

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -384,13 +384,13 @@ void TabPage::onFileSizeChanged(const QModelIndex& index) {
 void TabPage::onFilesAdded(Fm::FileInfoList files) {
     if(static_cast<Application*>(qApp)->settings().selectNewFiles()) {
         if(!selectionTimer_) {
-            folderView_->selectFiles(files, false);
             selectionTimer_ = new QTimer (this);
             selectionTimer_->setSingleShot(true);
-            selectionTimer_->start(200);
+            if(folderView_->selectFiles(files, false)) {
+                selectionTimer_->start(200);
+            }
         }
-        else {
-            folderView_->selectFiles(files, selectionTimer_->isActive());
+        else if(folderView_->selectFiles(files, selectionTimer_->isActive())) {
             selectionTimer_->start(200);
         }
     }


### PR DESCRIPTION
The selection timer should have been started only if something was really selected. The fix is for very rare situations, where a hidden (temporary) file is created and removed instantly.

This depends on https://github.com/lxqt/libfm-qt/pull/760