### PR TITLE
Changed shortcut for bulk rename

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -867,7 +867,7 @@
     <string>Bulk Rename</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+F2</string>
+    <string>Shift+F2</string>
    </property>
   </action>
   <action name="actionShowFilter">


### PR DESCRIPTION
Never worked. Ctrl+F2 is already used in lxqt-globalkeys for "Switch to Desktop 2", same in ` ~/.config/kglobalshortcutsrc`
