### PR TITLE
Preselect based on starting characters with transient filter bar

### DIFF
--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -45,6 +45,7 @@ class Launcher;
 
 class ProxyFilter : public Fm::ProxyFolderModelFilter {
 public:
+    ProxyFilter() : fullName_{true} {}
     bool filterAcceptsRow(const Fm::ProxyFolderModel* model, const std::shared_ptr<const Fm::FileInfo>& info) const;
     virtual ~ProxyFilter() {}
     QString getFilterStr() {
@@ -53,8 +54,12 @@ public:
     void setFilterStr(QString str) {
         filterStr_ = str;
     }
+    void filterFullName(bool fullName) {
+        fullName_ = fullName;
+    }
 
 private:
+    bool fullName_;
     QString filterStr_;
 };
 


### PR DESCRIPTION
Previously, the first visible item was preselected.

Also, the filtering behavior is enhanced. Now, if `Preferences → Display → Always show real file names` is not checked, filtering will be done based on the display name. This is useful inside folders like `/usr/share/applications`.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1566