### PR TITLE
Added search history

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -523,6 +523,8 @@ void Application::onFindFileAccepted() {
     settings_.setSearchContentRegexp(dlg->contentRegexp());
     settings_.setSearchRecursive(dlg->recursive());
     settings_.setSearchhHidden(dlg->searchhHidden());
+    settings_.addNamePattern(dlg->namePattern());
+    settings_.addContentPattern(dlg->contentPattern());
 
     Fm::FilePathList paths;
     paths.emplace_back(dlg->searchUri());
@@ -551,6 +553,8 @@ void Application::findFiles(QStringList paths) {
     dlg->setContentRegexp(settings_.searchContentRegexp());
     dlg->setRecursive(settings_.searchRecursive());
     dlg->setSearchhHidden(settings_.searchhHidden());
+    dlg->addNamePatterns(settings_.namePatterns());
+    dlg->addContentPatterns(settings_.contentPatterns());
 
     dlg->show();
 }

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -817,7 +817,7 @@ A value of -1 means that there is no limit for the file size (the default).</str
         </layout>
        </widget>
        <widget class="QWidget" name="advancedPage">
-        <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,1">
+        <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0,1">
          <item>
           <widget class="QGroupBox" name="groupBox">
            <property name="title">
@@ -907,6 +907,45 @@ A value of -1 means that there is no limit for the file size (the default).</str
              <widget class="QCheckBox" name="templateRunApp">
               <property name="text">
                <string>Run default application after creation from template</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBox_10">
+           <property name="title">
+            <string>Search</string>
+           </property>
+           <layout class="QFormLayout" name="formLayout_4">
+            <property name="fieldGrowthPolicy">
+             <enum>QFormLayout::ExpandingFieldsGrow</enum>
+            </property>
+            <property name="horizontalSpacing">
+             <number>5</number>
+            </property>
+            <property name="verticalSpacing">
+             <number>5</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_19">
+              <property name="text">
+               <string>Maximum search history:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QSpinBox" name="maxSearchHistory">
+              <property name="maximum">
+               <number>50</number>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0" colspan="2">
+             <widget class="QToolButton" name="clearSearchHistory">
+              <property name="text">
+               <string>Clear search history</string>
               </property>
              </widget>
             </item>

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -278,6 +278,8 @@ void PreferencesDialog::initAdvancedPage(Settings& settings) {
 
     // FIXME: Hide options that we don't support yet.
     ui.templateRunApp->hide();
+
+    ui.maxSearchHistory->setValue(settings.maxSearchHistory());
 }
 
 void PreferencesDialog::initFromSettings() {
@@ -288,6 +290,10 @@ void PreferencesDialog::initFromSettings() {
     initThumbnailPage(settings);
     initVolumePage(settings);
     initAdvancedPage(settings);
+
+    connect(ui.clearSearchHistory, &QAbstractButton::clicked, [this, &settings] {
+        settings.clearSearchHistory();
+    });
 }
 
 void PreferencesDialog::applyDisplayPage(Settings& settings) {
@@ -379,6 +385,8 @@ void PreferencesDialog::applyAdvancedPage(Settings& settings) {
     settings.setOnlyUserTemplates(ui.onlyUserTemplates->isChecked());
     settings.setTemplateTypeOnce(ui.templateTypeOnce->isChecked());
     settings.setTemplateRunApp(ui.templateRunApp->isChecked());
+
+    settings.setMaxSearchHistory(ui.maxSearchHistory->value());
 }
 
 

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -973,6 +973,26 @@ public:
         searchhHidden_ = hidden;
     }
 
+    int maxSearchHistory() const {
+        return maxSearchHistory_;
+    }
+
+    void setMaxSearchHistory(int max);
+
+    void clearSearchHistory();
+
+    QStringList namePatterns() const {
+        return namePatterns_;
+    }
+
+    void addNamePattern(const QString& pattern);
+
+    QStringList contentPatterns() const {
+        return contentPatterns_;
+    }
+
+    void addContentPattern(const QString& pattern);
+
     QList<int> getCustomColumnWidths() const {
         QList<int> l;
         for(auto width : qAsConst(customColumnWidths_)) {
@@ -1137,6 +1157,9 @@ private:
     bool searchContentRegexp_;
     bool searchRecursive_;
     bool searchhHidden_;
+    int maxSearchHistory_;
+    QStringList namePatterns_;
+    QStringList contentPatterns_;
 
     // detailed list columns
     QList<QVariant> customColumnWidths_;


### PR DESCRIPTION
This patch requires https://github.com/lxqt/libfm-qt/pull/806.

The history items can be selected by Up and Down arrow keys or by opening the combo menu.

For respecting the user's privacy, the maximum search history is zero (= disabled) by default. It can be from 0 to 50, with separate lists for the name and content entries.

Also, a button is added to Preferences dialog for clearing the search history.

The options are in preferences → Advanced → Search.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1580