### PR TITLE
Prevent an empty desktop path

### DIFF
--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -27,7 +27,6 @@
 #include <QFile>
 #include <QDir>
 #include <QSaveFile>
-#include <QRegExp>
 #include <QDebug>
 #include <QStandardPaths>
 #include <libfm-qt/filedialog.h>

--- a/pcmanfm/xdgdir.cpp
+++ b/pcmanfm/xdgdir.cpp
@@ -18,9 +18,12 @@
 
 #include "xdgdir.h"
 #include <QStandardPaths>
+#include <QRegularExpression>
 #include <QFile>
 #include <QDir>
 #include <QSaveFile>
+
+static const QRegularExpression desktopRegex(QStringLiteral("XDG_DESKTOP_DIR=\"([^\n]*)\""));
 
 QString XdgDir::readUserDirsFile() {
     QFile file(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + QStringLiteral("/user-dirs.dirs"));
@@ -34,30 +37,33 @@ QString XdgDir::readUserDirsFile() {
 
 QString XdgDir::readDesktopDir() {
     QString str = readUserDirsFile();
-    if(str.isEmpty())
-        return QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + QStringLiteral("/Desktop");
-    QRegExp reg(QStringLiteral("XDG_DESKTOP_DIR=\"([^\n]*)\""));
-    if(reg.lastIndexIn(str) != -1) {
-        str = reg.cap(1);
-        if(str.startsWith(QStringLiteral("$HOME")))
-            str = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + str.mid(5);
-        return str;
+    if(!str.isEmpty()) {
+        QRegularExpressionMatch match;
+        if(str.lastIndexOf(desktopRegex, -1, &match) != -1) {
+            str = match.captured(1);
+            if(str.startsWith(QStringLiteral("$HOME"))) {
+                str = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + str.mid(5);
+            }
+            return str;
+        }
     }
-    return QString();
+    return QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + QStringLiteral("/Desktop");
 }
 
 void XdgDir::setDesktopDir(QString path) {
     QString home = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
-    if(path.startsWith(home))
+    if(path.startsWith(home)) {
         path = QStringLiteral("$HOME") + path.mid(home.length());
+    }
     QString str = readUserDirsFile();
-    QRegExp reg(QStringLiteral("XDG_DESKTOP_DIR=\"([^\n]*)\""));
     QString line = QStringLiteral("XDG_DESKTOP_DIR=\"") + path + QLatin1Char('\"');
-    if(reg.indexIn(str) != -1)
-        str.replace(reg, line);
+    if(str.contains(desktopRegex)) {
+        str.replace(desktopRegex, line);
+    }
     else {
-        if(!str.endsWith(QLatin1Char('\n')))
+        if(!str.endsWith(QLatin1Char('\n'))) {
             str += QLatin1Char('\n');
+        }
         str += line + QLatin1Char('\n');
     }
     QString dir = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);


### PR DESCRIPTION
Fall back to `$HOME/Desktop` if `~/.config/user-dirs.dirs` doesn't exist or doesn't contain a desktop path. But if `~/.config/user-dirs.dirs` contains an empty desktop path, accept it.

See https://github.com/lxqt/lxqt-session/issues/439 for the story.