### PR TITLE
Add option for leading zeros in "Bulk Rename"

### DIFF
--- a/pcmanfm/bulk-rename.ui
+++ b/pcmanfm/bulk-rename.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>BulkRenameDialog</class>
  <widget class="QDialog" name="BulkRenameDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>388</width>
+    <height>155</height>
+   </rect>
+  </property>
   <property name="windowTitle">
    <string>Bulk Rename</string>
   </property>
@@ -82,6 +90,13 @@
      </property>
      <property name="text">
       <string>Name#</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QCheckBox" name="leadingZeros">
+     <property name="text">
+      <string>Use leading zeros</string>
      </property>
     </widget>
    </item>

--- a/pcmanfm/bulkrename.cpp
+++ b/pcmanfm/bulkrename.cpp
@@ -25,6 +25,9 @@
 
 #include <libfm-qt/utilities.h>
 
+#include <math.h>
+#include <string.h>
+
 namespace PCManFM {
 
 BulkRenameDialog::BulkRenameDialog(QWidget* parent, Qt::WindowFlags flags) :
@@ -44,6 +47,19 @@ void BulkRenameDialog::showEvent(QShowEvent* event) {
             ui.lineEdit->setSelection(0, ui.lineEdit->text().size() - 1);
         });
     }
+}
+
+QString BulkRenamer::withLeadingZeros(int n, int size){
+    QString str = QString::number(n);
+
+    // Don't prepend zeros for big numbers
+    if(size - str.size() <= 0){
+        return str;
+    }
+
+    std::string zeros(size - str.size(), '0');
+
+    return (QString::fromStdString(zeros) + str);
 }
 
 BulkRenamer::BulkRenamer(const Fm::FileInfoList& files, QWidget* parent) {
@@ -96,8 +112,11 @@ BulkRenamer::BulkRenamer(const Fm::FileInfoList& files, QWidget* parent) {
                 newName += match.captured();
             }
         }
+        QString replacement = dlg.useLeadingZeros()
+            ? withLeadingZeros(start + i, log10(files.size()) + 1)
+            : QString::number(start + i);
 
-        newName.replace(QLatin1Char('#'), QString::number(start + i));
+        newName.replace(QLatin1Char('#'), replacement);
         if (newName == fileName || !Fm::changeFileName(file->path(), newName, nullptr, false)) {
             ++failed;
         }

--- a/pcmanfm/bulkrename.h
+++ b/pcmanfm/bulkrename.h
@@ -38,6 +38,9 @@ public:
     int getStart() const {
         return ui.spinBox->value();
     }
+    bool useLeadingZeros() const {
+        return ui.leadingZeros->isChecked();
+    }
 
 protected:
     virtual void showEvent(QShowEvent* event) override;
@@ -50,6 +53,9 @@ class BulkRenamer {
 public:
     BulkRenamer(const Fm::FileInfoList& files, QWidget* parent = nullptr);
     ~BulkRenamer();
+
+private:
+    QString withLeadingZeros(int n, int size);
 };
 
 }


### PR DESCRIPTION
Useful when there is more than ten files and you want to keep the right order in eg. the terminal.

![image](https://user-images.githubusercontent.com/7745032/175475457-d9becf11-d81b-4e76-9de4-9a003ec11460.png)
