### PR TITLE
Ignore auto-selection delay when single-click isn't chosen

### DIFF
--- a/pcmanfm/view.cpp
+++ b/pcmanfm/view.cpp
@@ -168,7 +168,7 @@ void View::updateFromSettings(Settings& settings) {
 
     setMargins(settings.folderViewCellMargins());
 
-    setAutoSelectionDelay(settings.autoSelectionDelay());
+    setAutoSelectionDelay(settings.singleClick() ? settings.autoSelectionDelay() : 0);
 
     setCtrlRightClick(settings.ctrlRightClick());
 


### PR DESCRIPTION
And even when the DE's setting is single-click activation.

Fixes https://github.com/lxqt/pcmanfm-qt/issues/1625