### PR TITLE
Apply changes in shared settings to Desktop too

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -127,6 +127,7 @@ DesktopWindow::DesktopWindow(int screenNum):
         proxyModel_ = new Fm::ProxyFolderModel();
         proxyModel_->setSourceModel(model_);
         proxyModel_->setShowThumbnails(settings.showThumbnails());
+        proxyModel_->setBackupAsHidden(settings.backupAsHidden());
         proxyModel_->sort(settings.desktopSortColumn(), settings.desktopSortOrder());
         proxyModel_->setFolderFirst(settings.desktopSortFolderFirst());
         proxyModel_->setHiddenLast(settings.desktopSortHiddenLast());
@@ -888,6 +889,14 @@ void DesktopWindow::nextWallpaper() {
 }
 
 void DesktopWindow::updateFromSettings(Settings& settings, bool changeSlide) {
+    // geneeral PCManFM::View settings
+    setAutoSelectionDelay(settings.singleClick() ? settings.autoSelectionDelay() : 0);
+    setCtrlRightClick(settings.ctrlRightClick());
+    if(proxyModel_) {
+        proxyModel_->setShowThumbnails(settings.showThumbnails());
+        proxyModel_->setBackupAsHidden(settings.backupAsHidden());
+    }
+
     setDesktopFolder();
     setWallpaperFile(settings.wallpaper());
     setWallpaperMode(settings.wallpaperMode());


### PR DESCRIPTION
The settings shared by Desktop and windows are auto-delay selection, right-click behavior, showing of thumbnails and treating backup files as hidden. Now, they're applied on the fly.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1642