### PR TITLE
Corrected bulk renaming shortcut on Desktop

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -172,7 +172,7 @@ DesktopWindow::DesktopWindow(int screenNum):
     shortcut = new QShortcut(QKeySequence(Qt::Key_F2), this); // rename
     connect(shortcut, &QShortcut::activated, this, &DesktopWindow::onRenameActivated);
 
-    shortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_F2), this); // bulk rename
+    shortcut = new QShortcut(QKeySequence(Qt::SHIFT + Qt::Key_F2), this); // bulk rename
     connect(shortcut, &QShortcut::activated, this, &DesktopWindow::onBulkRenameActivated);
 
     shortcut = new QShortcut(QKeySequence(Qt::ALT + Qt::Key_Return), this); // properties


### PR DESCRIPTION
It's `Shift+F2` in windows, but it was `Ctrl+F2` on Desktop (noticed it when correcting the Wiki).