### PR TITLE
Set QTerminal in default config file for LXQt

### DIFF
--- a/config/pcmanfm-qt/lxqt/settings.conf.in
+++ b/config/pcmanfm-qt/lxqt/settings.conf.in
@@ -2,11 +2,9 @@
 IconThemeName=elementary
 FallbackIconThemeName=breeze
 SuCommand=lxsudo dbus-run-session -- %s
-TerminalCommand=
 Archiver=lxqt-archiver
 SIUnit=false
-TerminalDirCommand=xterm
-TerminalExecCommand=xterm -e %s
+Terminal=qterminal
 
 [Behavior]
 BookmarkOpenMethod=0


### PR DESCRIPTION
Also, removed redundant keys from old times

Closes https://github.com/lxqt/pcmanfm-qt/issues/1647