### PR TITLE
Fixed a small problem in tab DND

### DIFF
--- a/pcmanfm/tabbar.cpp
+++ b/pcmanfm/tabbar.cpp
@@ -104,6 +104,11 @@ void TabBar::releaseMouse() {
 }
 
 void TabBar::mouseReleaseEvent(QMouseEvent *event) {
+    if(detachable_) { // reset drag info
+        dragStarted_ = false;
+        dragStartPosition_ = QPoint();
+    }
+
     if (event->button() == Qt::MiddleButton) {
         int index = tabAt(event->pos());
         if (index != -1) {

--- a/pcmanfm/tabbar.h
+++ b/pcmanfm/tabbar.h
@@ -37,6 +37,9 @@ public:
 
     void setDetachable(bool detachable) {
         detachable_ = detachable;
+        // also, reset drag info
+        dragStarted_ = false;
+        dragStartPosition_ = QPoint();
     }
 
 Q_SIGNALS:


### PR DESCRIPTION
Drag info should have been reset on releasing mouse button.

The issue this patch fixes can be seen by dragging a tab just a little and releasing it, so that it returns to its previous position. After that, all tabs of that window (except for the last remaining one) could be thrown outside it by dragging them from their close buttons.