### PR TITLE
Don't try to activate windows under Wayland

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -96,6 +96,8 @@ Application::Application(int& argc, char** argv):
 
     setApplicationVersion(QStringLiteral(PCMANFM_QT_VERSION));
 
+    underWayland_ = QGuiApplication::platformName() == QStringLiteral("wayland");
+
     // QDBusConnection::sessionBus().registerObject("/org/pcmanfm/Application", this);
     QDBusConnection dbus = QDBusConnection::sessionBus();
     if(dbus.registerService(QLatin1String(serviceName))) {

--- a/pcmanfm/application.h
+++ b/pcmanfm/application.h
@@ -72,6 +72,10 @@ public:
         return libFm_;
     }
 
+    bool underWayland() const {
+      return underWayland_;
+    }
+
     // public interface exported via dbus
     void launchFiles(const QString& cwd, const QStringList& paths, bool inNewWindow, bool reopenLastTabs);
     void setWallpaper(const QString& path, const QString& modeString);
@@ -153,6 +157,8 @@ private:
     QString userDirsFile_;
     QString userDesktopFolder_;
     bool lxqtRunning_;
+
+    bool underWayland_;
 
     int argc_;
     char** argv_;

--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -1110,8 +1110,10 @@ void DesktopWindow::onCreatingShortcut() {
         filesToTrust_ << name;
     });
     dlg->show();
-    dlg->raise();
-    dlg->activateWindow();
+    if(!static_cast<Application*>(qApp)->underWayland()) {
+        dlg->raise();
+        dlg->activateWindow();
+    }
 }
 
 void DesktopWindow::onDesktopPreferences() {

--- a/pcmanfm/launcher.cpp
+++ b/pcmanfm/launcher.cpp
@@ -80,8 +80,10 @@ bool Launcher::openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folder
         mainWindow->addTab(std::move(path));
     }
     mainWindow->show();
-    mainWindow->raise();
-    mainWindow->activateWindow();
+    if(!app->underWayland()) {
+        mainWindow->raise();
+        mainWindow->activateWindow();
+    }
     openInNewTab_ = false;
     return true;
 }

--- a/pcmanfm/tabpage.cpp
+++ b/pcmanfm/tabpage.cpp
@@ -1074,8 +1074,10 @@ void TabPage::ceateShortcut() {
                 }
             });
             dlg->show();
-            dlg->raise();
-            dlg->activateWindow();
+            if(!static_cast<Application*>(qApp)->underWayland()) {
+                dlg->raise();
+                dlg->activateWindow();
+            }
         }
     }
 }


### PR DESCRIPTION
Because it would be futile and give a warning message.

Later, if we decide on the Wayland compositor(s) we want to support, we might replace the changed blocks with Wayland codes.