### PR TITLE
Leave the pixmap cache limit to Qt

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -28,7 +28,6 @@
 #include <QVector>
 #include <QLocale>
 #include <QLibraryInfo>
-#include <QPixmapCache>
 #include <QFile>
 #include <QMessageBox>
 #include <QCommandLineParser>
@@ -238,8 +237,6 @@ bool Application::parseCommandLineArgs() {
         QString perFolderConfigFile = settings_.profileDir(profileName_) + QStringLiteral("/dir-settings.conf");
         Fm::FolderConfig::init(perFolderConfigFile.toLocal8Bit().constData());
 
-        // decrease the cache size to reduce memory usage
-        QPixmapCache::setCacheLimit(2048);
 
         if(settings_.useFallbackIconTheme()) {
             QIcon::setThemeName(settings_.fallbackIconThemeName());


### PR DESCRIPTION
The code caused extra CPU usage in special cases by reducing the pixmap cache limit to 2048 KB (Qt's default is 10240 KB).

Closes https://github.com/lxqt/libfm-qt/issues/874