### PR TITLE
Added a title to desktop

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -88,6 +88,9 @@ DesktopWindow::DesktopWindow(int screenNum):
     setAttribute(Qt::WA_X11NetWmWindowTypeDesktop);
     setAttribute(Qt::WA_DeleteOnClose);
 
+    // the title can be used for setting WM rules, especially under Wayland compositors
+    setWindowTitle(QStringLiteral("pcmanfm-desktop") + QString::number(screenNum_));
+
     // set our custom file launcher
     View::setFileLauncher(&fileLauncher_);
 


### PR DESCRIPTION
The title is `pcmanfm-desktop<N>`, where `<N>` is the screen number (0 for usual setups). It can be used for setting WM rules, especially under Wayland compositors.

For now, the same title isn't prevented in pcmanfm-qt windows, but that will be easy to implement if really needed.