### PR TITLE
A small fix to tab text localization

### DIFF
--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -313,6 +313,7 @@ protected Q_SLOTS:
 private:
     void freeFolder();
     QString formatStatusText();
+    void localizeTitle(const Fm::FilePath& path);
 
     void onFolderStartLoading();
     void onFolderFinishLoading();


### PR DESCRIPTION
Previously, on entering a special folder, the tab text was in English in a moment and then changed to the target language quickly.