### PR TITLE
Remove desktop's drop indicator on leaving desktop

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -1892,6 +1892,10 @@ bool DesktopWindow::eventFilter(QObject* watched, QEvent* event) {
         case QEvent::Wheel:
             // removal of scrollbars is not enough to prevent scrolling
             return true;
+        case QEvent::DragLeave:
+            // remove the drop indicator on leaving the widget during DND
+            dropRect_ = QRect();
+            break;
         default:
             break;
         }


### PR DESCRIPTION
Leaving the desktop during DND over a folder can happen under rare circumstances.