### PR TITLE
Keep dragged and dropped items together on Desktop

### DIFF
--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -150,7 +150,9 @@ private:
     void addDesktopActions(QMenu* menu);
     void paintBackground(QPaintEvent* event);
     void paintDropIndicator();
-    bool stickToPosition(const std::string& file, QPoint& pos, const QRect& workArea, const QSize& grid, bool reachedLastCell = false);
+    bool stickToPosition(const std::string& file, QPoint& pos,
+                         const QRect& workArea, const QSize& grid,
+                         const std::set<std::string>& droppedFiles,  bool reachedLastCell);
     static void alignToGrid(QPoint& pos, const QPoint& topLeft, const QSize& grid, const int spacing);
 
     void updateShortcutsFromSettings(Settings& settings);


### PR DESCRIPTION
This patch preserves the order of dragged and dropped Desktop items as far as possible.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1750