### PR TITLE
Check if wallpaper cache is up-to-date on reading Desktop settings

### DIFF
--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -72,7 +72,7 @@ public:
     void setWallpaperRandomize(bool randomize);
 
     // void setWallpaperAlpha(qreal alpha);
-    void updateWallpaper();
+    void updateWallpaper(bool checkMTime = false);
     bool pickWallpaper();
     void nextWallpaper();
     void updateFromSettings(Settings& settings, bool changeSlide = true);
@@ -99,7 +99,7 @@ protected:
     void retrieveCustomPos();
     void storeCustomPos();
 
-    QImage loadWallpaperFile(QSize requiredSize);
+    QImage loadWallpaperFile(QSize requiredSize, bool checkMTime);
 
     virtual bool event(QEvent* event) override;
     virtual bool eventFilter(QObject* watched, QEvent* event) override;


### PR DESCRIPTION
The modification time of the wallpaper file is checked to know if the cache is up-to-date, but only when Desktop settings are read (i.e., at startup or on applying Desktop Preferences).

This is needed when the wallpaper is changed but its path and name are not. It fixes https://github.com/lxqt/pcmanfm-qt/issues/1764