### PR TITLE
Tab-order fixes to Create Launcher and Desktop Preferences dialogs

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -162,6 +162,13 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>x</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="3">
            <widget class="QSpinBox" name="vMargin">
             <property name="toolTip">
@@ -198,13 +205,6 @@ A space is also reserved for 3 lines of text.</string>
              </size>
             </property>
            </spacer>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="label_8">
-            <property name="text">
-             <string>x</string>
-            </property>
-           </widget>
           </item>
           <item row="1" column="0" colspan="6" alignment="Qt::AlignLeft">
            <widget class="QGroupBox" name="groupBox_7">

--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -139,47 +139,10 @@
           <property name="verticalSpacing">
            <number>10</number>
           </property>
-          <item row="0" column="4">
-           <widget class="QCheckBox" name="lockMargins">
-            <property name="text">
-             <string>Lock</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label_7">
             <property name="text">
              <string>Minimum item margins:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="5">
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>5</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="0" column="3">
-           <widget class="QSpinBox" name="vMargin">
-            <property name="toolTip">
-             <string>1 px by default.
-A space is also reserved for 3 lines of text.</string>
-            </property>
-            <property name="suffix">
-             <string> px</string>
-            </property>
-            <property name="maximum">
-             <number>48</number>
-            </property>
-            <property name="value">
-             <number>1</number>
             </property>
            </widget>
           </item>
@@ -198,6 +161,43 @@ A space is also reserved for 3 lines of text.</string>
              <number>3</number>
             </property>
            </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QSpinBox" name="vMargin">
+            <property name="toolTip">
+             <string>1 px by default.
+A space is also reserved for 3 lines of text.</string>
+            </property>
+            <property name="suffix">
+             <string> px</string>
+            </property>
+            <property name="maximum">
+             <number>48</number>
+            </property>
+            <property name="value">
+             <number>1</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4">
+           <widget class="QCheckBox" name="lockMargins">
+            <property name="text">
+             <string>Lock</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="5">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>5</height>
+             </size>
+            </property>
+           </spacer>
           </item>
           <item row="0" column="2">
            <widget class="QLabel" name="label_8">
@@ -492,6 +492,13 @@ are left clicked, even when it is not the default file manager.</string>
             </property>
            </widget>
           </item>
+          <item row="1" column="0" colspan="6">
+           <widget class="QLineEdit" name="imageFolder">
+            <property name="placeholderText">
+             <string>Wallpaper folder</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="6">
            <widget class="QPushButton" name="folderBrowse">
             <property name="text">
@@ -557,13 +564,6 @@ are left clicked, even when it is not the default file manager.</string>
              </size>
             </property>
            </spacer>
-          </item>
-          <item row="1" column="0" colspan="6">
-           <widget class="QLineEdit" name="imageFolder">
-            <property name="placeholderText">
-             <string>Wallpaper folder</string>
-            </property>
-           </widget>
           </item>
           <item row="2" column="1">
            <spacer name="horizontalSpacer_3">

--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -711,38 +711,6 @@ are left clicked, even when it is not the default file manager.</string>
    <header location="global">libfm-qt/fontbutton.h</header>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>tabWidget</tabstop>
-  <tabstop>iconSize</tabstop>
-  <tabstop>font</tabstop>
-  <tabstop>textColor</tabstop>
-  <tabstop>shadowColor</tabstop>
-  <tabstop>hMargin</tabstop>
-  <tabstop>vMargin</tabstop>
-  <tabstop>lockMargins</tabstop>
-  <tabstop>topMargin</tabstop>
-  <tabstop>leftMargin</tabstop>
-  <tabstop>rightMargin</tabstop>
-  <tabstop>bottomMargin</tabstop>
-  <tabstop>defaultFileManager</tabstop>
-  <tabstop>allSticky</tabstop>
-  <tabstop>backgroundColor</tabstop>
-  <tabstop>wallpaperMode</tabstop>
-  <tabstop>imageFile</tabstop>
-  <tabstop>browse</tabstop>
-  <tabstop>transformImage</tabstop>
-  <tabstop>perScreenWallpaper</tabstop>
-  <tabstop>slideShow</tabstop>
-  <tabstop>imageFolder</tabstop>
-  <tabstop>folderBrowse</tabstop>
-  <tabstop>hours</tabstop>
-  <tabstop>minutes</tabstop>
-  <tabstop>randomize</tabstop>
-  <tabstop>homeBox</tabstop>
-  <tabstop>trashBox</tabstop>
-  <tabstop>computerBox</tabstop>
-  <tabstop>networkBox</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -711,6 +711,38 @@ are left clicked, even when it is not the default file manager.</string>
    <header location="global">libfm-qt/fontbutton.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>iconSize</tabstop>
+  <tabstop>font</tabstop>
+  <tabstop>textColor</tabstop>
+  <tabstop>shadowColor</tabstop>
+  <tabstop>hMargin</tabstop>
+  <tabstop>vMargin</tabstop>
+  <tabstop>lockMargins</tabstop>
+  <tabstop>topMargin</tabstop>
+  <tabstop>leftMargin</tabstop>
+  <tabstop>rightMargin</tabstop>
+  <tabstop>bottomMargin</tabstop>
+  <tabstop>defaultFileManager</tabstop>
+  <tabstop>allSticky</tabstop>
+  <tabstop>backgroundColor</tabstop>
+  <tabstop>wallpaperMode</tabstop>
+  <tabstop>imageFile</tabstop>
+  <tabstop>browse</tabstop>
+  <tabstop>transformImage</tabstop>
+  <tabstop>perScreenWallpaper</tabstop>
+  <tabstop>slideShow</tabstop>
+  <tabstop>imageFolder</tabstop>
+  <tabstop>folderBrowse</tabstop>
+  <tabstop>hours</tabstop>
+  <tabstop>minutes</tabstop>
+  <tabstop>randomize</tabstop>
+  <tabstop>homeBox</tabstop>
+  <tabstop>trashBox</tabstop>
+  <tabstop>computerBox</tabstop>
+  <tabstop>networkBox</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/pcmanfm/desktopentrydialog.ui
+++ b/pcmanfm/desktopentrydialog.ui
@@ -235,18 +235,6 @@ Examples: AudioVideo, Audio, Video, Development, Education, Game, Graphics, Netw
    </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>nameEdit</tabstop>
-  <tabstop>descriptionEdit</tabstop>
-  <tabstop>commentEdit</tabstop>
-  <tabstop>catEdit</tabstop>
-  <tabstop>commandEdit</tabstop>
-  <tabstop>commandButton</tabstop>
-  <tabstop>iconEdit</tabstop>
-  <tabstop>iconButton</tabstop>
-  <tabstop>terminalCombo</tabstop>
-  <tabstop>typeCombo</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/pcmanfm/desktopentrydialog.ui
+++ b/pcmanfm/desktopentrydialog.ui
@@ -90,6 +90,27 @@ It can be left empty.</string>
        </property>
       </widget>
      </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="catLabel">
+       <property name="text">
+        <string>Categories:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="catEdit">
+       <property name="whatsThis">
+        <string>Semicolon separated categories in which the entry should be shown if it is used by the DE's main menu (e.g., when put inside ~/.local/share/applications).
+
+It is needed only when you want to use the created file in the main menu. Otherwise, you could leave it empty.
+
+Examples: AudioVideo, Audio, Video, Development, Education, Game, Graphics, Network, Office, Settings, System, Utility, Qt.</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
      <item row="4" column="0">
       <widget class="QLabel" name="commandLabel">
        <property name="text">
@@ -198,27 +219,6 @@ It can be left empty.</string>
          <string>Link</string>
         </property>
        </item>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="catLabel">
-       <property name="text">
-        <string>Categories:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QLineEdit" name="catEdit">
-       <property name="whatsThis">
-        <string>Semicolon separated categories in which the entry should be shown if it is used by the DE's main menu (e.g., when put inside ~/.local/share/applications).
-
-It is needed only when you want to use the created file in the main menu. Otherwise, you could leave it empty.
-
-Examples: AudioVideo, Audio, Video, Development, Education, Game, Graphics, Network, Office, Settings, System, Utility, Qt.</string>
-       </property>
-       <property name="clearButtonEnabled">
-        <bool>true</bool>
-       </property>
       </widget>
      </item>
     </layout>

--- a/pcmanfm/desktopentrydialog.ui
+++ b/pcmanfm/desktopentrydialog.ui
@@ -235,6 +235,18 @@ Examples: AudioVideo, Audio, Video, Development, Education, Game, Graphics, Netw
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>nameEdit</tabstop>
+  <tabstop>descriptionEdit</tabstop>
+  <tabstop>commentEdit</tabstop>
+  <tabstop>catEdit</tabstop>
+  <tabstop>commandEdit</tabstop>
+  <tabstop>commandButton</tabstop>
+  <tabstop>iconEdit</tabstop>
+  <tabstop>iconButton</tabstop>
+  <tabstop>terminalCombo</tabstop>
+  <tabstop>typeCombo</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
~Used Qt Designer to populate correct \<tabstops\>~ Rearranged .UI/XML blocks to correct tabbing for:
- Desktop -> Create Launcher dialog (pcmanfm/desktopentrydialog.ui)
- Desktop -> Desktop Preferences dialog (pcmanfm/desktop-preferences.ui)

I believe this is all for the tab order fixes on .ui files in PCManFM-Qt