### PR TITLE
Reordered XML elements: connect.ui, preferences.ui

### DIFF
--- a/pcmanfm/connect.ui
+++ b/pcmanfm/connect.ui
@@ -17,42 +17,6 @@
    <iconset theme="folder-remote"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="5" column="0" colspan="4">
-    <widget class="QRadioButton" name="anonymousLogin">
-     <property name="text">
-      <string>Anonymous &amp;login</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1" colspan="3">
-    <widget class="QLineEdit" name="path"/>
-   </item>
-   <item row="6" column="0">
-    <widget class="QRadioButton" name="loginAsUser">
-     <property name="text">
-      <string>Login as &amp;user:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="3">
-    <widget class="QLineEdit" name="userName"/>
-   </item>
-   <item row="1" column="1" colspan="3">
-    <widget class="QComboBox" name="serverType"/>
-   </item>
-   <item row="8" column="0" colspan="4">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0" colspan="4">
     <widget class="QLabel" name="label">
      <property name="sizePolicy">
@@ -73,10 +37,30 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="1" colspan="3">
+    <widget class="QComboBox" name="serverType"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Host:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="host"/>
+   </item>
    <item row="2" column="2">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Port:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="QSpinBox" name="port">
+     <property name="maximum">
+      <number>65535</number>
      </property>
     </widget>
    </item>
@@ -87,22 +71,28 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="host"/>
+   <item row="4" column="1" colspan="3">
+    <widget class="QLineEdit" name="path"/>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
+   <item row="5" column="0" colspan="4">
+    <widget class="QRadioButton" name="anonymousLogin">
      <property name="text">
-      <string>Host:</string>
+      <string>Anonymous &amp;login</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="2" column="3">
-    <widget class="QSpinBox" name="port">
-     <property name="maximum">
-      <number>65535</number>
+   <item row="6" column="0">
+    <widget class="QRadioButton" name="loginAsUser">
+     <property name="text">
+      <string>Login as &amp;user:</string>
      </property>
     </widget>
+   </item>
+   <item row="6" column="1" colspan="3">
+    <widget class="QLineEdit" name="userName"/>
    </item>
    <item row="7" column="0">
     <spacer name="verticalSpacer">
@@ -117,17 +107,18 @@
      </property>
     </spacer>
    </item>
+   <item row="8" column="0" colspan="4">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>serverType</tabstop>
-  <tabstop>host</tabstop>
-  <tabstop>port</tabstop>
-  <tabstop>path</tabstop>
-  <tabstop>anonymousLogin</tabstop>
-  <tabstop>loginAsUser</tabstop>
-  <tabstop>userName</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -107,16 +107,6 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
-             <widget class="QLabel" name="label_11">
-              <property name="text">
-               <string>Default view mode:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="1">
-             <widget class="QComboBox" name="viewMode"/>
-            </item>
             <item row="1" column="1">
              <widget class="QDoubleSpinBox" name="autoSelectionDelay">
               <property name="enabled">
@@ -130,6 +120,13 @@
               </property>
               <property name="singleStep">
                <double>0.100000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0" colspan="2">
+             <widget class="QCheckBox" name="ctrlRightClick">
+              <property name="text">
+               <string>Show folder context menu with Ctrl + right click</string>
               </property>
              </widget>
             </item>
@@ -159,12 +156,15 @@
               </item>
              </widget>
             </item>
-            <item row="2" column="0" colspan="2">
-             <widget class="QCheckBox" name="ctrlRightClick">
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_11">
               <property name="text">
-               <string>Show folder context menu with Ctrl + right click</string>
+               <string>Default view mode:</string>
               </property>
              </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QComboBox" name="viewMode"/>
             </item>
            </layout>
           </widget>
@@ -834,6 +834,13 @@ A value of -1 means that there is no limit for the file size (the default).</str
               </property>
              </widget>
             </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="terminal">
+              <property name="editable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
             <item row="1" column="0">
              <widget class="QLabel" name="label_3">
               <property name="text">
@@ -872,13 +879,6 @@ A value of -1 means that there is no limit for the file size (the default).</str
             </item>
             <item row="3" column="1">
              <widget class="QComboBox" name="archiver"/>
-            </item>
-            <item row="0" column="1">
-             <widget class="QComboBox" name="terminal">
-              <property name="editable">
-               <bool>true</bool>
-              </property>
-             </widget>
             </item>
            </layout>
           </widget>
@@ -999,60 +999,6 @@ A value of -1 means that there is no limit for the file size (the default).</str
    </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>listWidget</tabstop>
-  <tabstop>singleClick</tabstop>
-  <tabstop>autoSelectionDelay</tabstop>
-  <tabstop>ctrlRightClick</tabstop>
-  <tabstop>bookmarkOpenMethod</tabstop>
-  <tabstop>viewMode</tabstop>
-  <tabstop>configmDelete</tabstop>
-  <tabstop>useTrash</tabstop>
-  <tabstop>noUsbTrash</tabstop>
-  <tabstop>confirmTrash</tabstop>
-  <tabstop>quickExec</tabstop>
-  <tabstop>selectNewFiles</tabstop>
-  <tabstop>singleWindowMode</tabstop>
-  <tabstop>recentFilesSpinBox</tabstop>
-  <tabstop>iconTheme</tabstop>
-  <tabstop>bigIconSize</tabstop>
-  <tabstop>smallIconSize</tabstop>
-  <tabstop>thumbnailIconSize</tabstop>
-  <tabstop>sidePaneIconSize</tabstop>
-  <tabstop>siUnit</tabstop>
-  <tabstop>backupAsHidden</tabstop>
-  <tabstop>showFullNames</tabstop>
-  <tabstop>shadowHidden</tabstop>
-  <tabstop>noItemTooltip</tabstop>
-  <tabstop>noScrollPerPixel</tabstop>
-  <tabstop>hMargin</tabstop>
-  <tabstop>vMargin</tabstop>
-  <tabstop>lockMargins</tabstop>
-  <tabstop>alwaysShowTabs</tabstop>
-  <tabstop>showTabClose</tabstop>
-  <tabstop>switchToNewTab</tabstop>
-  <tabstop>rememberWindowSize</tabstop>
-  <tabstop>fixedWindowWidth</tabstop>
-  <tabstop>fixedWindowHeight</tabstop>
-  <tabstop>reopenLastTabs</tabstop>
-  <tabstop>showThumbnails</tabstop>
-  <tabstop>thumbnailLocal</tabstop>
-  <tabstop>maxThumbnailFileSize</tabstop>
-  <tabstop>maxExternalThumbnailFileSize</tabstop>
-  <tabstop>mountOnStartup</tabstop>
-  <tabstop>mountRemovable</tabstop>
-  <tabstop>autoRun</tabstop>
-  <tabstop>closeOnUnmount</tabstop>
-  <tabstop>goHomeOnUnmount</tabstop>
-  <tabstop>terminal</tabstop>
-  <tabstop>suCommand</tabstop>
-  <tabstop>archiver</tabstop>
-  <tabstop>onlyUserTemplates</tabstop>
-  <tabstop>templateTypeOnce</tabstop>
-  <tabstop>templateRunApp</tabstop>
-  <tabstop>maxSearchHistory</tabstop>
-  <tabstop>clearSearchHistory</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Affected files:
- pcmanfm/connect.ui
- pcmanfm/preferences.ui

After this there is no usage of \<tabstops\> in PCManFM-Qt's 10 .ui files. Also they have all been checked to see that tab-order is correct.