### PR TITLE
Prevent invisible bulk renaming dialog dialog under Wayland

### DIFF
--- a/pcmanfm/bulkrename.cpp
+++ b/pcmanfm/bulkrename.cpp
@@ -34,7 +34,7 @@ BulkRenameDialog::BulkRenameDialog(QWidget* parent, Qt::WindowFlags flags) :
     connect(ui.buttonBox->button(QDialogButtonBox::Ok), &QAbstractButton::clicked, this, &QDialog::accept);
     connect(ui.buttonBox->button(QDialogButtonBox::Cancel), &QAbstractButton::clicked, this, &QDialog::reject);
     resize(minimumSize());
-    setMaximumHeight(minimumHeight()); // no vertical resizing
+    setMaximumHeight(minimumSizeHint().height()); // no vertical resizing
 }
 
 void BulkRenameDialog::showEvent(QShowEvent* event) {


### PR DESCRIPTION
Under Wayland and with Qt6, `QWidget::minimumHeight()` is zero for a dialog before it's shown. It's better to be cautious with Qt5 too.