### PR TITLE
Fix tabs being reopened in incorrect view frame

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -625,10 +625,13 @@ void Application::launchFiles(const QString& cwd, const QStringList& paths, bool
         }
         auto launcher = Launcher(window);
         launcher.openInNewTab();
-        launcher.launchPaths(nullptr, pathList, splitIndex);
+        launcher.setSplitIndex(splitIndex);
+        launcher.launchPaths(nullptr, pathList);
     }
     else {
-        Launcher(nullptr).launchPaths(nullptr, pathList, splitIndex);
+        auto launcher = Launcher(nullptr);
+        launcher.setSplitIndex(splitIndex);
+        launcher.launchPaths(nullptr, pathList);
     }
 
     // if none of the last tabs can be opened and there is no main window yet,

--- a/pcmanfm/launcher.cpp
+++ b/pcmanfm/launcher.cpp
@@ -30,6 +30,7 @@ Launcher::Launcher(PCManFM::MainWindow* mainWindow):
     Fm::FileLauncher(),
     mainWindow_(mainWindow),
     openInNewTab_(false),
+    splitIndex_(0),
     openWithDefaultFileManager_(false) {
 
     Application* app = static_cast<Application*>(qApp);
@@ -38,12 +39,12 @@ Launcher::Launcher(PCManFM::MainWindow* mainWindow):
 
 Launcher::~Launcher() = default;
 
-bool Launcher::openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folderInfos, size_t splitIndex, Fm::GErrorPtr& /*err*/) {
+bool Launcher::openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folderInfos, Fm::GErrorPtr& /*err*/) {
     auto fi = folderInfos[0];
     Application* app = static_cast<Application*>(qApp);
     MainWindow* mainWindow = mainWindow_;
     Fm::FilePath path = fi->path();
-    bool openSplit = splitIndex > 0 && splitIndex < folderInfos.size();
+    bool openSplit = splitIndex_ > 0 && splitIndex_ < folderInfos.size();
     // Index of the first frame if we are doing a split open, else default to the active frame.
     int frameIndex = openSplit ? 0 : -1;
     if(!mainWindow) {
@@ -78,16 +79,16 @@ bool Launcher::openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folder
     }
 
     if(!openSplit) {
-        splitIndex = folderInfos.size();
+        splitIndex_ = folderInfos.size();
     }
 
-    for(size_t i = 1; i < splitIndex; ++i) {
+    for(size_t i = 1; i < splitIndex_; ++i) {
         fi = folderInfos[i];
         path = fi->path();
         mainWindow->addTab(std::move(path), frameIndex);
     }
     if(openSplit) {
-        fi = folderInfos[splitIndex];
+        fi = folderInfos[splitIndex_];
         path = fi->path();
         if(mainWindow_) {
             // We are adding tabs to the right frame of an existing window.
@@ -97,7 +98,7 @@ bool Launcher::openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folder
             mainWindow->chdir(std::move(path), 1);
         }
 
-        for(size_t i = splitIndex + 1; i < folderInfos.size(); ++i) {
+        for(size_t i = splitIndex_ + 1; i < folderInfos.size(); ++i) {
             fi = folderInfos[i];
             path = fi->path();
             mainWindow->addTab(std::move(path), 1);

--- a/pcmanfm/launcher.h
+++ b/pcmanfm/launcher.h
@@ -48,7 +48,7 @@ public:
     }
 
 protected:
-    bool openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folderInfos, Fm::GErrorPtr& err) override;
+    bool openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folderInfos, size_t splitIndex, Fm::GErrorPtr& err) override;
     void launchedFiles(const Fm::FileInfoList& files) const override;
     void launchedPaths(const Fm::FilePathList& paths) const override;
 

--- a/pcmanfm/launcher.h
+++ b/pcmanfm/launcher.h
@@ -40,6 +40,10 @@ public:
         openInNewTab_ = true;
     }
 
+    void setSplitIndex(size_t splitIndex) {
+        splitIndex_ = splitIndex;
+    }
+
     bool openWithDefaultFileManager() const {
         return openWithDefaultFileManager_;
     }
@@ -48,13 +52,14 @@ public:
     }
 
 protected:
-    bool openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folderInfos, size_t splitIndex, Fm::GErrorPtr& err) override;
+    bool openFolder(GAppLaunchContext* ctx, const Fm::FileInfoList& folderInfos, Fm::GErrorPtr& err) override;
     void launchedFiles(const Fm::FileInfoList& files) const override;
     void launchedPaths(const Fm::FilePathList& paths) const override;
 
 private:
     MainWindow* mainWindow_;
     bool openInNewTab_;
+    size_t splitIndex_;
     bool openWithDefaultFileManager_;
 };
 

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -1351,20 +1351,30 @@ void MainWindow::closeEvent(QCloseEvent* event) {
 
     // remember last tab paths only if this is the last window
     QStringList tabPaths;
+    size_t splitIndex = 0;
     if(lastActive_ == nullptr && settings.reopenLastTabs()) {
+        QStringList frameTabPaths;
         for(int i = 0; i < ui.viewSplitter->count(); ++i) {
             if(ViewFrame* viewFrame = qobject_cast<ViewFrame*>(ui.viewSplitter->widget(i))) {
+                frameTabPaths.clear();
                 int n = viewFrame->getStackedWidget()->count();
                 for(int j = 0; j < n; ++j) {
                     if(TabPage* page = static_cast<TabPage*>(viewFrame->getStackedWidget()->widget(j))) {
-                        tabPaths.append(QString::fromUtf8(page->path().toString().get()));
+                        frameTabPaths.append(QString::fromUtf8(page->path().toString().get()));
                     }
                 }
+                frameTabPaths.removeDuplicates();
+                // If there are multiple frames, set splitIndex to the index of the first item in
+                // the second frame.
+                if(splitIndex == 0 && tabPaths.size() > 0) {
+                    splitIndex = tabPaths.size();
+                }
+                tabPaths.append(frameTabPaths);
             }
         }
-        tabPaths.removeDuplicates();
     }
     settings.setTabPaths(tabPaths);
+    settings.setSplitIndex(splitIndex);
 }
 
 void MainWindow::onTabBarCurrentChanged(int index) {

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -80,11 +80,29 @@ public:
     virtual ~MainWindow();
 
     void chdir(Fm::FilePath path, ViewFrame* viewFrame);
+    void chdir(Fm::FilePath path, int frameIndex) {
+        ViewFrame* viewFrame = qobject_cast<ViewFrame*>(ui.viewSplitter->widget(frameIndex));
+
+        if (viewFrame == nullptr) {
+            viewFrame = activeViewFrame_;
+        }
+
+        chdir(path, viewFrame);
+    }
     void chdir(Fm::FilePath path) {
         chdir(path, activeViewFrame_);
     }
 
     void addTab(Fm::FilePath path, ViewFrame* viewFrame);
+    void addTab(Fm::FilePath path, int frameIndex) {
+        ViewFrame* viewFrame = qobject_cast<ViewFrame*>(ui.viewSplitter->widget(frameIndex));
+
+        if (viewFrame == nullptr) {
+            viewFrame = activeViewFrame_;
+        }
+
+        addTab(path, viewFrame);
+    }
     void addTab(Fm::FilePath path) {
         addTab(path, activeViewFrame_);
     }

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -98,6 +98,7 @@ Settings::Settings():
     sidePaneMode_(Fm::SidePane::ModePlaces),
     showMenuBar_(true),
     splitView_(false),
+    splitIndex_(0),
     viewMode_(Fm::FolderView::IconMode),
     showHidden_(false),
     sortOrder_(Qt::AscendingOrder),
@@ -349,6 +350,7 @@ bool Settings::loadFile(QString filePath) {
     sidePaneMode_ = sidePaneModeFromString(settings.value(QStringLiteral("SidePaneMode")).toString());
     showMenuBar_ = settings.value(QStringLiteral("ShowMenuBar"), true).toBool();
     splitView_ = settings.value(QStringLiteral("SplitView"), false).toBool();
+    splitIndex_ = settings.value(QStringLiteral("SplitIndex"), 0).toUInt();
     pathBarButtons_ = settings.value(QStringLiteral("PathBarButtons"), true).toBool();
     settings.endGroup();
 
@@ -501,6 +503,7 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue(QStringLiteral("SidePaneMode"), QString::fromUtf8(sidePaneModeToString(sidePaneMode_)));
     settings.setValue(QStringLiteral("ShowMenuBar"), showMenuBar_);
     settings.setValue(QStringLiteral("SplitView"), splitView_);
+    settings.setValue(QStringLiteral("SplitIndex"), (unsigned)splitIndex_);
     settings.setValue(QStringLiteral("PathBarButtons"), pathBarButtons_);
     settings.endGroup();
 

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -581,6 +581,14 @@ public:
         splitView_ = split;
     }
 
+    size_t splitIndex() const {
+        return splitIndex_;
+    }
+
+    void setSplitIndex(size_t splitIndex) {
+        splitIndex_ = splitIndex;
+    }
+
     Fm::FolderView::ViewMode viewMode() const {
         return viewMode_;
     }
@@ -1108,6 +1116,7 @@ private:
     Fm::SidePane::Mode sidePaneMode_;
     bool showMenuBar_;
     bool splitView_;
+    size_t splitIndex_;
 
     Fm::FolderView::ViewMode viewMode_;
     bool showHidden_;


### PR DESCRIPTION
Fix all tabs being reopened in the first view frame when both split view and reopen last window tabs are enabled.

Fixes #1329.