### PR TITLE
Consider split view on restoring tabs

### DIFF
--- a/pcmanfm/application.h
+++ b/pcmanfm/application.h
@@ -72,6 +72,10 @@ public:
         return libFm_;
     }
 
+    bool openingLastTabs() const {
+      return openingLastTabs_;
+    }
+
     bool underWayland() const {
       return underWayland_;
     }
@@ -157,6 +161,7 @@ private:
     QString userDirsFile_;
     QString userDesktopFolder_;
     bool lxqtRunning_;
+    bool openingLastTabs_;
 
     bool underWayland_;
 

--- a/pcmanfm/mainwindow.h
+++ b/pcmanfm/mainwindow.h
@@ -85,9 +85,7 @@ public:
     }
 
     void addTab(Fm::FilePath path, ViewFrame* viewFrame);
-    void addTab(Fm::FilePath path) {
-        addTab(path, activeViewFrame_);
-    }
+    void addTab(Fm::FilePath path);
 
     TabPage* currentPage(ViewFrame* viewFrame) {
         return reinterpret_cast<TabPage*>(viewFrame->getStackedWidget()->currentWidget());
@@ -282,6 +280,8 @@ private:
     // The split mode of this window is changed only from its settings,
     // not from another window. So, we get the mode at the start and keep it.
     bool splitView_;
+
+    int splitTabsNum_; // number of tabs to be restored from the first view frame of the last window
 
     static QPointer<MainWindow> lastActive_;
 };

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -87,6 +87,7 @@ Settings::Settings():
     showTabClose_(true),
     switchToNewTab_(false),
     reopenLastTabs_(false),
+    splitViewTabsNum_(0),
     rememberWindowSize_(true),
     fixedWindowWidth_(640),
     fixedWindowHeight_(480),
@@ -344,6 +345,7 @@ bool Settings::loadFile(QString filePath) {
     switchToNewTab_ = settings.value(QStringLiteral("SwitchToNewTab"), false).toBool();
     reopenLastTabs_ = settings.value(QStringLiteral("ReopenLastTabs"), false).toBool();
     tabPaths_ = settings.value(QStringLiteral("TabPaths")).toStringList();
+    splitViewTabsNum_ = settings.value(QStringLiteral("SplitViewTabsNum")).toInt();
     splitterPos_ = settings.value(QStringLiteral("SplitterPos"), 150).toInt();
     sidePaneVisible_ = settings.value(QStringLiteral("SidePaneVisible"), true).toBool();
     sidePaneMode_ = sidePaneModeFromString(settings.value(QStringLiteral("SidePaneMode")).toString());
@@ -496,6 +498,7 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue(QStringLiteral("SwitchToNewTab"), switchToNewTab_);
     settings.setValue(QStringLiteral("ReopenLastTabs"), reopenLastTabs_);
     settings.setValue(QStringLiteral("TabPaths"), tabPaths_);
+    settings.setValue(QStringLiteral("SplitViewTabsNum"), splitViewTabsNum_);
     settings.setValue(QStringLiteral("SplitterPos"), splitterPos_);
     settings.setValue(QStringLiteral("SidePaneVisible"), sidePaneVisible_);
     settings.setValue(QStringLiteral("SidePaneMode"), QString::fromUtf8(sidePaneModeToString(sidePaneMode_)));

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -470,6 +470,14 @@ public:
         reopenLastTabs_ = reopenLastTabs;
     }
 
+    int splitViewTabsNum() const {
+        return splitViewTabsNum_;
+    }
+
+    void setSplitViewTabsNum(int n) {
+        splitViewTabsNum_ = n;
+    }
+
     QStringList tabPaths() const {
         return tabPaths_;
     }
@@ -1096,6 +1104,7 @@ private:
     bool showTabClose_;
     bool switchToNewTab_;
     bool reopenLastTabs_;
+    int splitViewTabsNum_; // number of tabs in the first view frame when reopening last tabs
     QStringList tabPaths_;
     bool rememberWindowSize_;
     int fixedWindowWidth_;


### PR DESCRIPTION
The credit goes to @riverbl for the main idea.

 Also, restoring of tabs with equal paths are allowed now because the option is about tabs, not just their paths (this should have been done before).

Closes https://github.com/lxqt/pcmanfm-qt/issues/1329