### PR TITLE
Allow users to add terminal commands

### DIFF
--- a/pcmanfm/preferencesdialog.h
+++ b/pcmanfm/preferencesdialog.h
@@ -43,6 +43,7 @@ public:
 
 protected Q_SLOTS:
     void lockMargins(bool lock);
+    void terminalContextMenu(const QPoint& p);
 
 private:
     void initIconThemes(Settings& settings);
@@ -54,6 +55,8 @@ private:
     void initVolumePage(Settings& settings);
     void initAdvancedPage(Settings& settings);
     void initTerminals(Settings& settings);
+
+    void applyTerminal(Settings& settings);
 
     void applyUiPage(Settings& settings);
     void applyDisplayPage(Settings& settings);


### PR DESCRIPTION
Now, the terminal command entered by the user will be added to the list of terminals if the Preferences dialog is accepted (by pressing the OK button or pressing Enter inside the combo).

The format is as shown by the GUI, except for the redundant `%s`, which I didn't remove for the sake of translations — it's harmless. In most cases, just the terminal command is enough (without option).

The user can also right click inside the combo and remove a terminal if added previously or open the user-defined list if existing.

This PR is made based on https://github.com/lxqt/libfm-qt/pull/924 and needs it to work.