### PR TITLE
 Add 5 menu icons to the main window (main-win.ui)

### DIFF
--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -17,7 +17,6 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-
 #ifndef PCMANFM_DESKTOPWINDOW_H
 #define PCMANFM_DESKTOPWINDOW_H
 

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -490,6 +490,10 @@
    </property>
   </action>
   <action name="actionSelectAll">
+   <property name="icon">
+    <iconset theme="edit-select-all">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Select &amp;All</string>
    </property>
@@ -722,6 +726,10 @@
    </property>
   </action>
   <action name="actionOpenTerminal">
+   <property name="icon">
+    <iconset theme="utilities-terminal">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Open &amp;Terminal</string>
    </property>
@@ -848,6 +856,10 @@
    </property>
   </action>
   <action name="actionConnectToServer">
+   <property name="icon">
+    <iconset theme="network-server">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>Connect to &amp;Server</string>
    </property>

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -684,6 +684,10 @@
    </property>
   </action>
   <action name="actionFileProperties">
+   <property name="icon">
+    <iconset theme="document-properties">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>File &amp;Properties</string>
    </property>
@@ -713,6 +717,10 @@
    </property>
   </action>
   <action name="actionCloseWindow">
+   <property name="icon">
+    <iconset theme="window-close">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>&amp;Close Window</string>
    </property>


### PR DESCRIPTION
5 menu icons added to the main window's toolbar menus: namely 'edit-select-all', 'utilities-terminal', 'network-server'

The icons exist in well-known icon sets; the Adwaita icon set has them but in "-symbolic" form.