### PR TITLE
Fixed a regression is setting wallpaper with command-line

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -685,9 +685,15 @@ void Application::setWallpaper(const QString& path, const QString& modeString) {
         }
     }
 
-    DesktopWindow::WallpaperMode mode = DesktopWindow::WallpaperMode(Settings::wallpaperModeFromString(modeString));
-    if(mode != settings_.wallpaperMode()) {
-        changed = true;
+    DesktopWindow::WallpaperMode mode;
+    if(modeString.isEmpty()) {
+        mode = settings_.wallpaperMode();
+    }
+    else {
+        mode = DesktopWindow::WallpaperMode(Settings::wallpaperModeFromString(modeString));
+        if(mode != settings_.wallpaperMode()) {
+            changed = true;
+        }
     }
 
     // FIXME: support different wallpapers on different screen.


### PR DESCRIPTION
The regression resulted in an empty background when the wallpaper was set by command-line without specifying its mode, i.e., by

```
pcmanfm-qt --set-wallpaper <FILE>
```

Fixes https://github.com/lxqt/lxqt/issues/2511