### PR TITLE
Disabled root instance under Wayland

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -392,6 +392,10 @@ MainWindow::MainWindow(Fm::FilePath path):
     if(QApplication::layoutDirection() == Qt::RightToLeft) {
         setRTLIcons(true);
     }
+
+    if(static_cast<Application*>(qApp)->underWayland()) {
+        ui.actionOpenAsRoot->setEnabled(false);
+    }
 }
 
 MainWindow::~MainWindow() = default;

--- a/pcmanfm/preferences.ui
+++ b/pcmanfm/preferences.ui
@@ -842,7 +842,7 @@ A value of -1 means that there is no limit for the file size (the default).</str
              </widget>
             </item>
             <item row="1" column="0">
-             <widget class="QLabel" name="label_3">
+             <widget class="QLabel" name="suLabel">
               <property name="text">
                <string>Switch &amp;user command:</string>
               </property>

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -54,6 +54,11 @@ PreferencesDialog::PreferencesDialog(const QString& activePage, QWidget* parent)
 
     selectPage(activePage);
     adjustSize();
+
+    if(static_cast<Application*>(qApp)->underWayland()) {
+        ui.suCommand->setEnabled(false);
+        ui.suLabel->setEnabled(false);
+    }
 }
 
 PreferencesDialog::~PreferencesDialog() = default;


### PR DESCRIPTION
Wayland doesn't like a root instance. A root instance may be possible by using XWayland, but it is neither recommended nor for ordinary users.