### PR TITLE
Add 8 menu icons

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -1108,7 +1108,7 @@ void DesktopWindow::addDesktopActions(QMenu* menu) {
         action = menu->addAction(tr("Create Launcher"));
         connect(action, &QAction::triggered, this, &DesktopWindow::onCreatingShortcut);
     }
-    action = menu->addAction(tr("Desktop Preferences"));
+    action = menu->addAction(QIcon::fromTheme(QStringLiteral("preferences-desktop")), tr("Desktop Preferences"));
     connect(action, &QAction::triggered, this, &DesktopWindow::onDesktopPreferences);
 }
 

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -80,6 +80,10 @@
      <property name="title">
       <string>Recent F&amp;iles</string>
      </property>
+     <property name="icon">
+      <iconset theme="document-open-recent">
+       <normaloff>.</normaloff>.</iconset>
+     </property>
     </widget>
     <addaction name="actionNewTab"/>
     <addaction name="actionNewWin"/>
@@ -392,6 +396,10 @@
    <property name="text">
     <string>&amp;Network</string>
    </property>
+   <property name="icon">
+    <iconset theme="folder-network">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
   </action>
   <action name="actionDesktop">
    <property name="icon">
@@ -521,6 +529,10 @@
    <property name="text">
     <string>&amp;Ascending</string>
    </property>
+   <property name="icon">
+    <iconset theme="view-sort-ascending">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
   </action>
   <action name="actionDescending">
    <property name="checkable">
@@ -528,6 +540,10 @@
    </property>
    <property name="text">
     <string>&amp;Descending</string>
+   </property>
+   <property name="icon">
+    <iconset theme="view-sort-descending">
+     <normaloff>.</normaloff>.</iconset>
    </property>
   </action>
   <action name="actionByFileName">
@@ -676,6 +692,10 @@
    </property>
   </action>
   <action name="actionCloseTab">
+   <property name="icon">
+    <iconset theme="tab-close">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="text">
     <string>C&amp;lose Tab</string>
    </property>
@@ -782,6 +802,10 @@
   <action name="actionFindFiles">
    <property name="text">
     <string>&amp;Find Files</string>
+   </property>
+   <property name="icon">
+    <iconset theme="edit-find">
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="shortcut">
     <string>F3</string>
@@ -927,6 +951,10 @@
   <action name="actionCopyFullPath">
    <property name="text">
     <string>&amp;Copy Full Path</string>
+   </property>
+   <property name="icon">
+    <iconset theme="edit-copy">
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+C</string>

--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -687,6 +687,10 @@
    <property name="text">
     <string>&amp;Rename</string>
    </property>
+   <property name="icon">
+    <iconset theme="edit-rename">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
    <property name="shortcut">
     <string>F2</string>
    </property>
@@ -915,6 +919,10 @@
   <action name="actionBulkRename">
    <property name="text">
     <string>&amp;Bulk Rename</string>
+   </property>
+   <property name="icon">
+    <iconset theme="edit-rename">
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="toolTip">
     <string>Bulk Rename</string>


### PR DESCRIPTION
7 more icons to the menu bar, 1 to desktop menu

Menu bar:
 - File → Close Tab [tab-close]
 - File → Recent Files [document-open-recent]
 - View → Sorting -> Ascending [view-sort-ascending]
 - View → Sorting -> Descending [view-sort-descending]
 - Go → Network [folder-network]
 - Tools → Copy Full Path [edit-copy]
 - Tools → Find Files [edit-find]

 Desktop menu:
 - Desktop Preferences [preferences-desktop]