### PR TITLE
Add option to toggle ShellQt in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,13 @@ find_package(Qt6LinguistTools ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6Widgets ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(fm-qt6 ${LIBFMQT_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt2-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
-find_package(LayerShellQt ${SHELLQT_MINIMUM_VERSION} REQUIRED)
+
+option(ENABLE_SHELLQT "Enable ShellQt if building for Wayland" ON)
+if(ENABLE_SHELLQT)
+    add_definitions(-DUSE_ENABLE_SHELLQT)
+    find_package(LayerShellQt ${SHELLQT_MINIMUM_VERSION} REQUIRED)
+endif()
+
 
 message(STATUS "Building ${PROJECT_NAME} with Qt ${Qt6Core_VERSION}")
 

--- a/pcmanfm/CMakeLists.txt
+++ b/pcmanfm/CMakeLists.txt
@@ -87,12 +87,18 @@ target_include_directories(pcmanfm-qt
         "${Qt6Gui_PRIVATE_INCLUDE_DIRS}"
 )
 
-target_link_libraries(pcmanfm-qt
+set(LINK_LIBS
+    pcmanfm-qt
     Qt6::Widgets
     Qt6::DBus
-    LayerShellQtInterface
     fm-qt6
 )
+
+if(ENABLE_SHELLQT)
+    list(APPEND LINK_LIBS LayerShellQtInterface)
+endif()
+
+target_link_libraries(${LINK_LIBS})
 
 install(TARGETS pcmanfm-qt RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -43,9 +43,10 @@
 #include <QRandomGenerator>
 #include <QToolTip>
 
+#ifdef ENABLE_SHELLQT
 #include <LayerShellQt/shell.h>
 #include <LayerShellQt/window.h>
-
+#endif
 #include "./application.h"
 #include "mainwindow.h"
 #include <libfm-qt6/foldermenu.h>
@@ -190,6 +191,7 @@ DesktopWindow::DesktopWindow(int screenNum):
     shortcut = new QShortcut(QKeySequence(Qt::SHIFT | Qt::Key_Delete), this); // force delete
     connect(shortcut, &QShortcut::activated, this, &DesktopWindow::onDeleteActivated);
 
+#ifdef ENABLE_SHELLQT
     // set the layer and anchors under Wayland
     if(static_cast<Application*>(qApp)->underWayland()) {
         winId();
@@ -207,6 +209,7 @@ DesktopWindow::DesktopWindow(int screenNum):
             }
         }
     }
+#endif
 }
 
 DesktopWindow::~DesktopWindow() {


### PR DESCRIPTION
So today I went about building `pcmanfm-qt` from source.  

I am targeting X11 rather than Wayland. However, the build step fails because it requires `LayerShellQt`. To use it requires building it from source. Unfortunately, this requires that I have Qt configured with QWayland module. 

If I enable `QWayland` then Qt complains that `Error: ‘QX11Application’ is not a member of ‘QNativeInterface` So that is why I've added the following option so I can exclude LayerShellQt if I am not targeting Wayland in any way. 

@tsujan @stefonarch 
