### PR TITLE
Trim leading and trailing spaces to prevent issues when copying text …

### DIFF
--- a/pcmanfm/connectserverdialog.cpp
+++ b/pcmanfm/connectserverdialog.cpp
@@ -75,10 +75,10 @@ void ConnectServerDialog::onCurrentIndexChanged(int /*index*/) {
 
 void ConnectServerDialog::checkInput() {
   bool valid = true;
-  if(ui.host->text().isEmpty()) {
+  if(ui.host->text().trimmed().isEmpty()) {
     valid = false;
   }
-  else if(ui.loginAsUser->isChecked() && ui.userName->text().isEmpty()) {
+  else if(ui.loginAsUser->isChecked() && ui.userName->text().trimmed().isEmpty()) {
     valid = false;
   }
   ui.buttonBox->button(QDialogButtonBox::Ok)->setEnabled(valid);

--- a/pcmanfm/connectserverdialog.cpp
+++ b/pcmanfm/connectserverdialog.cpp
@@ -41,11 +41,11 @@ QString ConnectServerDialog::uriText() {
   uri = QString::fromLatin1(serverType.scheme);
   uri += QStringLiteral("://");
   if(ui.loginAsUser->isChecked()) {
-    uri += ui.userName->text();
+    uri += ui.userName->text().trimmed();
     uri += QLatin1Char('@');
   }
 
-  uri += ui.host->text();
+  uri += ui.host->text().trimmed();
   int port = ui.port->value();
   if(port != serverType.defaultPort) {
     uri += QLatin1Char(':');


### PR DESCRIPTION
Trim leading and trailing spaces to prevent issues when copying text  with extra spaces.  

Sometimes when I use it to connect to SFTP, I just copy the host into the input box, which may contain extra spaces, causing the connection to fail. Then I have to input everything again. So, I used `.trimmed()` to ignore these spaces.   

I hope this PR doesn't affect other functionalities and can be considered for adoption. 