### PR TITLE
Separate multi-screen desktops under Wayland

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -459,7 +459,8 @@ void Application::desktopManager(bool enabled) {
             // NOTE: there are two modes
             // When virtual desktop is used (all screens are combined to form a large virtual desktop),
             // we only create one DesktopWindow. Otherwise, we create one for each screen.
-            if(primaryScreen() && primaryScreen()->virtualSiblings().size() > 1) {
+            // Under Wayland, separate desktops are created for avoiding problems.
+            if(!underWayland_ && primaryScreen() && primaryScreen()->virtualSiblings().size() > 1) {
                 DesktopWindow* window = createDesktopWindow(-1);
                 desktopWindows_.push_back(window);
             }
@@ -934,7 +935,8 @@ void Application::onScreenAdded(QScreen* newScreen) {
         connect(newScreen, &QScreen::availableGeometryChanged, this, &Application::onAvailableGeometryChanged);
         connect(newScreen, &QObject::destroyed, this, &Application::onScreenDestroyed);
         const auto siblings = primaryScreen()->virtualSiblings();
-        if(siblings.contains(newScreen)) { // the primary screen is changed
+        if(!underWayland_ // Under Wayland, separate desktops are created for avoiding problems.
+           && siblings.contains(newScreen)) { // the primary screen is changed
             if(desktopWindows_.size() == 1) {
                 desktopWindows_.at(0)->setGeometry(newScreen->virtualGeometry());
                 if(siblings.size() > 1) { // a virtual desktop is created

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -83,7 +83,8 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
 
   if (mode == DesktopWindow::WallpaperStretch || mode == DesktopWindow::WallpaperCenter
       || mode == DesktopWindow::WallpaperFit || mode == DesktopWindow::WallpaperZoom) {
-    ui.perScreenWallpaper->setEnabled(true);
+    // Under Wayland, separate desktops are created for avoiding problems.
+    ui.perScreenWallpaper->setEnabled(!static_cast<Application*>(qApp)->underWayland());
   }
   else
     ui.perScreenWallpaper->setEnabled(false);
@@ -246,7 +247,8 @@ void DesktopPreferencesDialog::onWallpaperModeChanged(int index) {
 
   if (mode == DesktopWindow::WallpaperStretch || mode == DesktopWindow::WallpaperCenter
       || mode == DesktopWindow::WallpaperFit || mode == DesktopWindow::WallpaperZoom) {
-    ui.perScreenWallpaper->setEnabled(true);
+    // Under Wayland, separate desktops are created for avoiding problems.
+    ui.perScreenWallpaper->setEnabled(!static_cast<Application*>(qApp)->underWayland());
   }
   else
     ui.perScreenWallpaper->setEnabled(false);


### PR DESCRIPTION
For avoiding the problems of multi-screen desktops, each screen is given its separate desktop with a separate items layout under Wayland.

X11 isn't touched.

NOTE. IMO, this is the best solution for having multi-screen desktops under Wayland. The reason is a Wayland issue that limits an extended desktop to one screen as soon as any window is shown on a layer. A workaround for that issue was possible, but flickers couldn't be avoided.