### PR TITLE
Populate Bookmarks menu icons to match side pane

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -1796,6 +1796,7 @@ void MainWindow::loadBookmarksMenu() {
     QAction* before = ui.actionAddToBookmarks;
     for(auto& item: bookmarks_->items()) {
         BookmarkAction* action = new BookmarkAction(item, ui.menu_Bookmarks);
+        action->setIcon(item->icon()->qicon());
         connect(action, &QAction::triggered, this, &MainWindow::onBookmarkActionTriggered);
         ui.menu_Bookmarks->insertAction(before, action);
     }


### PR DESCRIPTION
One-line change

Uses the same icons in the side pane for the Bookmarks menu.