### PR TITLE
Add remaining icons to "Go" menu

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -396,10 +396,6 @@
    <property name="text">
     <string>&amp;Network</string>
    </property>
-   <property name="icon">
-    <iconset theme="folder-network">
-     <normaloff>.</normaloff>.</iconset>
-   </property>
   </action>
   <action name="actionDesktop">
    <property name="icon">

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -175,6 +175,9 @@ MainWindow::MainWindow(Fm::FilePath path):
     // menu
     ui.actionDelete->setText(settings.useTrash() ? tr("&Move to Trash") : tr("&Delete"));
     ui.actionDelete->setIcon(settings.useTrash() ? QIcon::fromTheme(QStringLiteral("user-trash")) : QIcon::fromTheme(QStringLiteral("edit-delete")));
+    ui.actionNetwork->setIcon(QIcon::fromTheme(QLatin1String("network"), QIcon::fromTheme(QLatin1String("folder-network"))));
+    ui.actionApplications->setIcon(QIcon::fromTheme(QLatin1String("system-software-install"),
+        QIcon::fromTheme(QLatin1String("applications-accessories"))));
 
     // side pane
     ui.sidePane->setVisible(settings.isSidePaneVisible());

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -175,9 +175,9 @@ MainWindow::MainWindow(Fm::FilePath path):
     // menu
     ui.actionDelete->setText(settings.useTrash() ? tr("&Move to Trash") : tr("&Delete"));
     ui.actionDelete->setIcon(settings.useTrash() ? QIcon::fromTheme(QStringLiteral("user-trash")) : QIcon::fromTheme(QStringLiteral("edit-delete")));
-    ui.actionNetwork->setIcon(QIcon::fromTheme(QLatin1String("network"), QIcon::fromTheme(QLatin1String("folder-network"))));
-    ui.actionApplications->setIcon(QIcon::fromTheme(QLatin1String("system-software-install"),
-        QIcon::fromTheme(QLatin1String("applications-accessories"))));
+    ui.actionNetwork->setIcon(QIcon::fromTheme(QStringLiteral("network"), QIcon::fromTheme(QStringLiteral("folder-network"))));
+    ui.actionApplications->setIcon(QIcon::fromTheme(QStringLiteral("system-software-install"),
+        QIcon::fromTheme(QStringLiteral("applications-accessories"))));
 
     // side pane
     ui.sidePane->setVisible(settings.isSidePaneVisible());


### PR DESCRIPTION
Give icons to 'Network' and 'Applications'

Icons (and fallback icons) were taken from the side pane (libfm-qt): https://github.com/lxqt/libfm-qt/blob/3375204b4d30a5239b9f56bb58a3a8c077fc9ba5/src/placesmodel.cpp#L63

It is not obvious how to set fallback icons in .ui XML, so I resorted to `setIcon`