### PR TITLE
Better drag-and-drop on Desktop

### DIFF
--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -151,7 +151,9 @@ private:
     void paintDropIndicator();
     bool stickToPosition(const std::string& file, QPoint& pos,
                          const QRect& workArea, const QSize& grid,
-                         const std::set<std::string>& droppedFiles,  bool reachedLastCell);
+                         bool reachedLastCell,
+                         const std::set<std::string>& droppedFiles,
+                         const std::set<std::string>& draggedFiles = std::set<std::string>{});
     static void alignToGrid(QPoint& pos, const QPoint& topLeft, const QSize& grid, const int spacing);
 
     void updateShortcutsFromSettings(Settings& settings);


### PR DESCRIPTION
Previously and under certain circumstances, if a selection of desktop items was dragged and dropped where no other item existed, some neighboring items might be displaced.

Fixes https://github.com/lxqt/pcmanfm-qt/issues/1969