### PR TITLE
Reorder "Go" menu

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -216,10 +216,10 @@
     </property>
     <addaction name="actionHome"/>
     <addaction name="actionDesktop"/>
-    <addaction name="actionComputer"/>
     <addaction name="actionTrash"/>
-    <addaction name="actionNetwork"/>
+    <addaction name="actionComputer"/>
     <addaction name="actionApplications"/>
+    <addaction name="actionNetwork"/>
     <addaction name="separator"/>
     <addaction name="actionGoBack"/>
     <addaction name="actionGoForward"/>


### PR DESCRIPTION
To match the default Places in the side pane.

The two menus are effectively the same, so matching them makes sense. The side pane's order takes precedent.