### PR TITLE
Set fallback icon to support more iconsets

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -658,10 +658,6 @@ are left clicked, even when it is not the default file manager.</string>
             <property name="text">
              <string>Network</string>
             </property>
-            <property name="icon">
-             <iconset theme="folder-network">
-              <normaloff>.</normaloff>.</iconset>
-            </property>
            </widget>
           </item>
          </layout>

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -122,6 +122,9 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
   ui.computerBox->setChecked(ds.contains(QLatin1String("Computer")));
   ui.networkBox->setChecked(ds.contains(QLatin1String("Network")));
 
+  // set fallback icon here (cannot be done in .ui)
+  ui.networkBox->setIcon(QIcon::fromTheme(QStringLiteral("network"), QIcon::fromTheme(QStringLiteral("folder-network"))));
+
   connect(ui.buttonBox->button(QDialogButtonBox::Apply), &QPushButton::clicked,
           this, &DesktopPreferencesDialog::onApplyClicked);
 


### PR DESCRIPTION
There are two standard names for this icon, depending on if an iconset has GTK or KDE roots. Fixes no icon being displayed in certain cases.