### PR TITLE
Update filesystem info appropriately, with a delay

### DIFF
--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -342,6 +342,7 @@ private:
     bool overrideCursor_;
     FolderSettings folderSettings_;
     QTimer* selectionTimer_;
+    QTimer* filesystemInfoTimer_;
     FilterBar* filterBar_;
     QStringList filesToTrust_;
     Fm::FilePathList filesToSelect_; // files to select


### PR DESCRIPTION
This patch updates the filesystem info ("Free space" on the statusbar) when all changes to the folder's contents are finished and the folder settles down, such that there is no extra I/O or CPU usage during changes.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1987

NOTE:
I'm a little concerned about this. As far as I've tested, and also based on what I know, I think it's compatible with the app's lightness. However, Dolphin doesn't do it, and Thunar does it only partially (only when files are added or removed, not when the size of a file grows or decreases). So, I'm not sure whether the devs of those apps — especially Thunar — have missed something, or I have ;)

So, I might not merge it (soon). Thorough tests would be very appreciated, particularly with remote filesystems that support this kind of info.