### PR TITLE
Better tab sizes

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -72,7 +72,6 @@ ViewFrame::ViewFrame(QWidget* parent):
 
     // tabbed browsing interface
     tabBar_->setDocumentMode(true);
-    tabBar_->setElideMode(Qt::ElideRight);
     tabBar_->setExpanding(false);
     tabBar_->setMovable(true); // reorder the tabs by dragging
     // switch to the tab under the cursor during dnd.

--- a/pcmanfm/tabbar.cpp
+++ b/pcmanfm/tabbar.cpp
@@ -34,6 +34,7 @@ TabBar::TabBar(QWidget *parent):
     dragStarted_(false),
     detachable_(true)
 {
+    setElideMode(Qt::ElideRight); // works with minimumTabSizeHint()
 }
 
 void TabBar::mousePressEvent(QMouseEvent *event) {
@@ -140,6 +141,26 @@ void TabBar::dragEnterEvent(QDragEnterEvent *event) {
     if(detachable_ && event->mimeData()->hasFormat(QStringLiteral("application/pcmanfm-qt-tab"))) {
         event->ignore();
     }
+}
+
+// Limit the size of large tabs to 2/3 of the width of the tabbar.
+QSize TabBar::tabSizeHint(int index) const {
+    switch (shape()) {
+    case QTabBar::RoundedWest:
+    case QTabBar::TriangularWest:
+    case QTabBar::RoundedEast:
+    case QTabBar::TriangularEast:
+        return QSize(QTabBar::tabSizeHint(index).width(),
+                     qMin(2 * height() / 3, QTabBar::tabSizeHint(index).height()));
+    default:
+        return QSize(qMin(2 * width() / 3, QTabBar::tabSizeHint(index).width()),
+                     QTabBar::tabSizeHint(index).height());
+    }
+}
+
+// Set minimumTabSizeHint to tabSizeHint to keep tabs from shrinking with eliding.
+QSize TabBar::minimumTabSizeHint(int index) const {
+    return tabSizeHint(index);
 }
 
 void TabBar::tabInserted(int index) {

--- a/pcmanfm/tabbar.h
+++ b/pcmanfm/tabbar.h
@@ -50,12 +50,13 @@ Q_SIGNALS:
     void tabDetached();
 
 protected:
-    void mouseReleaseEvent(QMouseEvent *event);
-    // from qtabbar.cpp
-    virtual void mousePressEvent(QMouseEvent *event);
-    virtual void mouseMoveEvent(QMouseEvent *event);
-    virtual void dragEnterEvent(QDragEnterEvent *event);
-    virtual void tabInserted(int index);
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    QSize tabSizeHint (int index) const override;
+    QSize minimumTabSizeHint (int index) const override;
+    void tabInserted(int index) override;
 
 private:
     QPoint dragStartPosition_;


### PR DESCRIPTION
Previously, a tab with a large enough text made the small texts of other tabs get elided.

The patch does two things. First, it limits the tab size to 2/3 of the width of the tabbar and, if needed, elides the text. Second, it prevents small tab texts from being elided, by making the best use of tab scroll buttons.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1990