### PR TITLE
Prevent going up with auto-repeated Backspace in transient filter-bar

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -339,16 +339,6 @@ MainWindow::MainWindow(Fm::FilePath path):
         connect(shortcut, &QShortcut::activated, this, &MainWindow::onShortcutJumpToTab);
     }
 
-    shortcut = new QShortcut(QKeySequence(Qt::Key_Backspace), this);
-    connect(shortcut, &QShortcut::activated, [this, &settings] {
-        // pass Backspace to current page if it has a visible, transient filter-bar
-        if(!settings.showFilter() && currentPage() && currentPage()->isFilterBarVisible()) {
-            currentPage()->backspacePressed();
-            return;
-        }
-        on_actionGoUp_triggered();
-    });
-
     shortcut = new QShortcut(QKeySequence(Qt::SHIFT | Qt::Key_Delete), this);
     connect(shortcut, &QShortcut::activated, this, &MainWindow::on_actionDelete_triggered);
 
@@ -703,6 +693,7 @@ int MainWindow::addTabWithPage(TabPage* page, ViewFrame* viewFrame, Fm::FilePath
     connect(page, &TabPage::sortFilterChanged, this, &MainWindow::onTabPageSortFilterChanged);
     connect(page, &TabPage::backwardRequested, this, &MainWindow::on_actionGoBack_triggered);
     connect(page, &TabPage::forwardRequested, this, &MainWindow::on_actionGoForward_triggered);
+    connect(page, &TabPage::backspacePressed, this, &MainWindow::on_actionGoUp_triggered);
     connect(page, &TabPage::folderUnmounted, this, &MainWindow::onFolderUnmounted);
 
     if(path) {

--- a/pcmanfm/tabpage.h
+++ b/pcmanfm/tabpage.h
@@ -283,8 +283,6 @@ public:
         }
     }
 
-    void backspacePressed();
-
     void createShortcut();
 
     void setFilesToSelect(const Fm::FilePathList& files) {
@@ -298,6 +296,7 @@ Q_SIGNALS:
     void forwardRequested();
     void backwardRequested();
     void folderUnmounted();
+    void backspacePressed();
 
 protected:
     virtual bool eventFilter(QObject* watched, QEvent* event);


### PR DESCRIPTION
If the transient filter-bar is shown and Backspace is kept pressed, no going-up will happen. But if the transient filter-bar is emptied and Backspace is released, its next press will still cause going up (although without auto-repeating).

This is the only possible compromise between keeping Backspace for going-up and preventing an unwanted going-up with the transient filter-bar.

NOTE: Pressing Backspace isn't a good way of clearing the transient filter-bar because the selected file may change. Pressing Escape is always the best and easiest way. I might add that to pcmanfm-qt's Wiki page.