### PR TITLE
Handle Wayland screens by using their names

### DIFF
--- a/pcmanfm/application.h
+++ b/pcmanfm/application.h
@@ -130,7 +130,7 @@ protected Q_SLOTS:
 protected:
     //virtual bool eventFilter(QObject* watched, QEvent* event);
     bool parseCommandLineArgs();
-    DesktopWindow* createDesktopWindow(int screenNum);
+    DesktopWindow* createDesktopWindow(int screenNum, const QString& screenName = QString());
     bool autoMountVolume(GVolume* volume, bool interactive = true);
 
     static void onVolumeAdded(GVolumeMonitor* monitor, GVolume* volume, Application* pThis);

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -56,7 +56,7 @@ public:
         WallpaperZoom
     };
 
-    explicit DesktopWindow(int screenNum);
+    explicit DesktopWindow(int screenNum, const QString& screenName = QString());
     virtual ~DesktopWindow();
 
     void setForeground(const QColor& color);
@@ -81,8 +81,12 @@ public:
     int screenNum() const {
         return screenNum_;
     }
-
     void setScreenNum(int num);
+
+    QString screenName() const {
+        return screenName_;
+    }
+    void setScreenName(const QString& name);
 
     QScreen* getDesktopScreen() const;
 
@@ -193,7 +197,8 @@ private:
     Launcher fileLauncher_;
     bool desktopHideItems_;
 
-    int screenNum_;
+    int screenNum_; // for X11
+    QString screenName_; // for Wayland
     std::unordered_map<std::string, QPoint> customItemPos_; // real custom positions
     std::unordered_map<std::string, QPoint> customPosStorage_; // savable custom positions
     QTimer* relayoutTimer_;


### PR DESCRIPTION
The main reason behind this change is that screen setting by using numbers may not work with all Wayland compositors.

With this patch, and on Wayland, the screen names are used for saving the arrangements of desktop items.

No change is made to X11 desktops.

NOTE: This is a backward incompatible change, in the sense that the arrangement of Wayland desktop items will be reset at first. But Wayland users could copy the contents of `desktop-items-0.conf` and paste it into `desktop-items-SCREEN_NAME.conf` after stopping the desktop module. That couldn't be done by the code, because it isn't known to which screen the old config file belonged (the number proves nothing).