### PR TITLE
Do not use "primary screen" on Wayland

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -971,14 +971,11 @@ void Application::onScreenRemoved(QScreen* oldScreen) {
         if(desktopWindows_.isEmpty()) {
             return;
         }
-        if(desktopWindows_.size() == 1) { // a single desktop is changed
+        if(!underWayland_ && desktopWindows_.size() == 1) { // a single desktop is changed
             if(primaryScreen() != nullptr) {
                 desktopWindows_.at(0)->setGeometry(primaryScreen()->virtualGeometry());
                 if(primaryScreen()->virtualSiblings().size() == 1) {
                     desktopWindows_.at(0)->setScreenNum(0); // there is no virtual desktop anymore
-                    if(underWayland_) {
-                        desktopWindows_.at(0)->setScreenName(primaryScreen()->name());
-                    }
                 }
             }
             else if (screens().isEmpty()) { // for the sake of certainty

--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -2450,17 +2450,6 @@ void DesktopWindow::setScreenNum(int num) {
     }
 }
 
-// Only on Wayland.
-void DesktopWindow::setScreenName(const QString& name) {
-    if(screenName_ != name) {
-        screenName_ = name;
-        if(static_cast<Application*>(qApp)->underWayland()) {
-            loadItemPositions();
-            queueRelayout();
-        }
-    }
-}
-
 QScreen* DesktopWindow::getDesktopScreen() const {
     QScreen* desktopScreen = nullptr;
     if(static_cast<Application*>(qApp)->underWayland()) {

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -86,7 +86,6 @@ public:
     QString screenName() const {
         return screenName_;
     }
-    void setScreenName(const QString& name);
 
     QScreen* getDesktopScreen() const;
 


### PR DESCRIPTION
… because Wayland doesn't have the concept of primary screen. Fortunately, `qApp->primaryScreen()` was never called in practice under Wayland.

Also, the code is simplified a little because `DesktopWindow::screenName` isn't needed anymore.