### PR TITLE
Add missing <cmath> headers

### DIFF
--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -28,6 +28,7 @@
 #include <QSettings>
 #include <QStandardPaths>
 
+#include <cmath>
 #include <algorithm>
 
 #include <libfm-qt6/folderview.h>


### PR DESCRIPTION
To check:
```
grep -R -P "(std::abs|std::round)"
grep -R "#include <cmath>"
```