### PR TITLE
increase default maximum size of thumbnailed images

### DIFF
--- a/config/pcmanfm-qt/lxqt/settings.conf.in
+++ b/config/pcmanfm-qt/lxqt/settings.conf.in
@@ -52,5 +52,5 @@ SidePaneMode=0
 
 [Thumbnail]
 ShowThumbnails=true
-MaxThumbnailFileSize=4096
+MaxThumbnailFileSize=40960
 ThumbnailLocalFilesOnly=true


### PR DESCRIPTION
fixes #2024

note: if it is not autogenerated then docs also need to be manually changed, see https://github.com/search?q=repo%3Alxqt%2Fpcmanfm-qt+4+image+size+limit&type=code&p=3 