### PR TITLE
Allow string replacement in bulk renaming

### DIFF
--- a/pcmanfm/bulk-rename.ui
+++ b/pcmanfm/bulk-rename.ui
@@ -6,23 +6,8 @@
    <string>Bulk Rename</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>5</number>
-   </property>
-   <property name="topMargin">
-    <number>5</number>
-   </property>
-   <property name="rightMargin">
-    <number>5</number>
-   </property>
-   <property name="bottomMargin">
-    <number>5</number>
-   </property>
-   <property name="spacing">
-    <number>5</number>
-   </property>
    <item row="0" column="0" colspan="3">
-    <widget class="QLabel" name="label1">
+    <widget class="QLabel" name="mainLabel">
      <property name="text">
       <string>Rename selected files to:</string>
      </property>
@@ -42,7 +27,7 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="label2">
+    <widget class="QLabel" name="startLabel">
      <property name="text">
       <string># will be replaced by numbers starting with:</string>
      </property>
@@ -94,7 +79,7 @@
       <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeType">
-      <enum>QSizePolicy::MinimumExpanding</enum>
+      <enum>QSizePolicy::Fixed</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -105,6 +90,103 @@
     </spacer>
    </item>
    <item row="6" column="0" colspan="3">
+    <widget class="QGroupBox" name="relaceGroupBox">
+     <property name="title">
+      <string>Replacement</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="findLabel">
+        <property name="text">
+         <string>Find in names:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="findLineEdit"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="replaceLabel">
+        <property name="text">
+         <string>Replace with:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="replaceLineEdit"/>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="caseBox">
+        <property name="text">
+         <string>Case-sensitive</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="regexBox">
+        <property name="text">
+         <string>Regular expression</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="3">
+    <widget class="QGroupBox" name="caseGroupBox">
+     <property name="title">
+      <string>Change Case</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QRadioButton" name="upperCaseButton">
+        <property name="text">
+         <string>To upper case</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="lowerCaseButton">
+        <property name="text">
+         <string>To lower case</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::MinimumExpanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>5</width>
+       <height>5</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="9" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>

--- a/pcmanfm/bulk-rename.ui
+++ b/pcmanfm/bulk-rename.ui
@@ -90,7 +90,7 @@
     </spacer>
    </item>
    <item row="6" column="0" colspan="3">
-    <widget class="QGroupBox" name="relaceGroupBox">
+    <widget class="QGroupBox" name="replaceGroupBox">
      <property name="title">
       <string>Replacement</string>
      </property>

--- a/pcmanfm/bulkrename.cpp
+++ b/pcmanfm/bulkrename.cpp
@@ -33,7 +33,7 @@ BulkRenameDialog::BulkRenameDialog(QWidget* parent, Qt::WindowFlags flags) :
     ui.lineEdit->setFocus();
     connect(ui.buttonBox->button(QDialogButtonBox::Ok), &QAbstractButton::clicked, this, &QDialog::accept);
     connect(ui.buttonBox->button(QDialogButtonBox::Cancel), &QAbstractButton::clicked, this, &QDialog::reject);
-    connect(ui.relaceGroupBox, &QGroupBox::clicked, this, [this](bool checked) {
+    connect(ui.replaceGroupBox, &QGroupBox::clicked, this, [this](bool checked) {
         ui.mainLabel->setEnabled(!checked);
         ui.lineEdit->setEnabled(!checked);
         ui.startLabel->setEnabled(!checked);
@@ -49,7 +49,7 @@ BulkRenameDialog::BulkRenameDialog(QWidget* parent, Qt::WindowFlags flags) :
         ui.spinBox->setEnabled(!checked);
         ui.zeroBox->setEnabled(!checked);
         ui.localeBox->setEnabled(!checked);
-        ui.relaceGroupBox->setChecked(false);
+        ui.replaceGroupBox->setChecked(false);
     });
 
     resize(minimumSize());

--- a/pcmanfm/bulkrename.cpp
+++ b/pcmanfm/bulkrename.cpp
@@ -33,6 +33,25 @@ BulkRenameDialog::BulkRenameDialog(QWidget* parent, Qt::WindowFlags flags) :
     ui.lineEdit->setFocus();
     connect(ui.buttonBox->button(QDialogButtonBox::Ok), &QAbstractButton::clicked, this, &QDialog::accept);
     connect(ui.buttonBox->button(QDialogButtonBox::Cancel), &QAbstractButton::clicked, this, &QDialog::reject);
+    connect(ui.relaceGroupBox, &QGroupBox::clicked, this, [this](bool checked) {
+        ui.mainLabel->setEnabled(!checked);
+        ui.lineEdit->setEnabled(!checked);
+        ui.startLabel->setEnabled(!checked);
+        ui.spinBox->setEnabled(!checked);
+        ui.zeroBox->setEnabled(!checked);
+        ui.localeBox->setEnabled(!checked);
+        ui.caseGroupBox->setChecked(false);
+    });
+    connect(ui.caseGroupBox, &QGroupBox::clicked, this, [this](bool checked) {
+        ui.mainLabel->setEnabled(!checked);
+        ui.lineEdit->setEnabled(!checked);
+        ui.startLabel->setEnabled(!checked);
+        ui.spinBox->setEnabled(!checked);
+        ui.zeroBox->setEnabled(!checked);
+        ui.localeBox->setEnabled(!checked);
+        ui.relaceGroupBox->setChecked(false);
+    });
+
     resize(minimumSize());
     setMaximumHeight(minimumSizeHint().height()); // no vertical resizing
 }
@@ -50,30 +69,64 @@ BulkRenamer::BulkRenamer(const Fm::FileInfoList& files, QWidget* parent) {
     if(files.size() <= 1) { // no bulk rename with just one file
         return;
     }
-    QString baseName;
+    bool replacement = false;
+    bool caseChange = false;
+    QString baseName, findStr, replaceStr;
     int start = 0;
     bool zeroPadding = false;
     bool respectLocale = false;
+    bool regex = false;
+    bool toUpperCase = false;
+    Qt::CaseSensitivity cs = Qt::CaseInsensitive;
     QLocale locale;
     BulkRenameDialog dlg(parent);
     switch(dlg.exec()) {
     case QDialog::Accepted:
-        baseName = dlg.getBaseName();
-        start = dlg.getStart();
-        zeroPadding = dlg.getZeroPadding();
-        respectLocale = dlg.getRespectLocale();
-        locale = dlg.locale();
+        if(dlg.getReplace()) {
+            replacement = true;
+            findStr = dlg.getFindStr();
+            replaceStr = dlg.getReplaceStr();
+            cs = dlg.getCase();
+            regex = dlg.getRegex();
+        }
+        if(dlg.getCaseChange()) {
+            caseChange = true;
+            toUpperCase = dlg.getUpperCase();
+            locale = dlg.locale();
+        }
+        else {
+            baseName = dlg.getBaseName();
+            start = dlg.getStart();
+            zeroPadding = dlg.getZeroPadding();
+            respectLocale = dlg.getRespectLocale();
+            locale = dlg.locale();
+        }
         break;
     default:
         return;
     }
 
+    if(replacement) {
+        renameByReplacing(files, findStr, replaceStr, cs, regex, parent);
+    }
+    else if(caseChange) {
+        renameByChangingCase(files, locale, toUpperCase, parent);
+    }
+    else {
+        rename(files, baseName, locale, start, zeroPadding, respectLocale, parent);
+    }
+}
+
+void BulkRenamer::rename(const Fm::FileInfoList& files,
+                         QString& baseName, const QLocale& locale,
+                         int start, bool zeroPadding, bool respectLocale,
+                         QWidget* parent) {
     // maximum space taken by numbers (if needed)
     int numSpace = zeroPadding ? QString::number(start + files.size()).size() : 0;
     // used for filling the space (if needed)
     const QChar zero = respectLocale ? !locale.zeroDigit().isEmpty()
-                                     ? locale.zeroDigit().at(0)
-                                     : QLatin1Char('0')
+                                       ? locale.zeroDigit().at(0)
+                                       : QLatin1Char('0')
                                      : QLatin1Char('0');
     // used for changing numbers to strings
     const QString specifier = respectLocale ? QStringLiteral("%L1") : QStringLiteral("%1");
@@ -114,7 +167,101 @@ BulkRenamer::BulkRenamer(const Fm::FileInfoList& files, QWidget* parent) {
         }
 
         newName.replace(QLatin1Char('#'), specifier.arg(start + i, numSpace, 10, zero));
-        if (newName == fileName || !Fm::changeFileName(file->path(), newName, nullptr, false)) {
+        if(newName == fileName || !Fm::changeFileName(file->path(), newName, nullptr, false)) {
+            ++failed;
+        }
+        ++i;
+    }
+    progress.setValue(i);
+    if(failed == i) {
+        QMessageBox::critical(parent, QObject::tr("Error"), QObject::tr("No file could be renamed."));
+    }
+    else if(failed > 0) {
+        QMessageBox::critical(parent, QObject::tr("Error"), QObject::tr("Some files could not be renamed."));
+    }
+}
+
+void BulkRenamer::renameByReplacing(const Fm::FileInfoList& files,
+                                    const QString& findStr, const QString& replaceStr,
+                                    Qt::CaseSensitivity cs, bool regex,
+                                    QWidget* parent) {
+    if(findStr.isEmpty()) {
+        QMessageBox::critical(parent, QObject::tr("Error"), QObject::tr("Nothing to find."));
+        return;
+    }
+    QRegularExpression regexFind;
+    if(regex) {
+        regexFind = QRegularExpression(findStr, cs == Qt::CaseSensitive
+                                                  ? QRegularExpression::NoPatternOption
+                                                  : QRegularExpression::CaseInsensitiveOption);
+        if(!regexFind.isValid()) {
+            QMessageBox::critical(parent, QObject::tr("Error"), QObject::tr("Invalid regular expression."));
+            return;
+        }
+    }
+    QProgressDialog progress(QObject::tr("Renaming files..."), QObject::tr("Abort"), 0, files.size(), parent);
+    progress.setWindowModality(Qt::WindowModal);
+    int i = 0, failed = 0;
+    for(auto& file: files) {
+        progress.setValue(i);
+        if(progress.wasCanceled()) {
+            progress.close();
+            QMessageBox::warning(parent, QObject::tr("Warning"), QObject::tr("Renaming is aborted."));
+            return;
+        }
+        auto fileName = QString::fromUtf8(g_file_info_get_edit_name(file->gFileInfo().get()));
+        if(fileName.isEmpty()) {
+            fileName = QString::fromStdString(file->name());
+        }
+
+        QString newName = fileName;
+        if(regex) {
+            newName.replace(regexFind, replaceStr);
+        }
+        else {
+            newName.replace(findStr, replaceStr, cs);
+        }
+        if(newName.isEmpty() || newName == fileName
+           || !Fm::changeFileName(file->path(), newName, nullptr, false)) {
+            ++failed;
+        }
+        ++i;
+    }
+    progress.setValue(i);
+    if(failed == i) {
+        QMessageBox::critical(parent, QObject::tr("Error"), QObject::tr("No file could be renamed."));
+    }
+    else if(failed > 0) {
+        QMessageBox::critical(parent, QObject::tr("Error"), QObject::tr("Some files could not be renamed."));
+    }
+}
+
+void BulkRenamer::renameByChangingCase(const Fm::FileInfoList& files, const QLocale& locale,
+                                       bool toUpperCase, QWidget* parent) {
+    QProgressDialog progress(QObject::tr("Renaming files..."), QObject::tr("Abort"), 0, files.size(), parent);
+    progress.setWindowModality(Qt::WindowModal);
+    int i = 0, failed = 0;
+    for(auto& file: files) {
+        progress.setValue(i);
+        if(progress.wasCanceled()) {
+            progress.close();
+            QMessageBox::warning(parent, QObject::tr("Warning"), QObject::tr("Renaming is aborted."));
+            return;
+        }
+        auto fileName = QString::fromUtf8(g_file_info_get_edit_name(file->gFileInfo().get()));
+        if(fileName.isEmpty()) {
+            fileName = QString::fromStdString(file->name());
+        }
+
+        QString newName;
+        if(toUpperCase){
+            newName = locale.toUpper(fileName);
+        }
+        else {
+            newName = locale.toLower(fileName);
+        }
+        if(newName.isEmpty() || newName == fileName
+           || !Fm::changeFileName(file->path(), newName, nullptr, false)) {
             ++failed;
         }
         ++i;

--- a/pcmanfm/bulkrename.h
+++ b/pcmanfm/bulkrename.h
@@ -32,6 +32,7 @@ Q_OBJECT
 public:
     explicit BulkRenameDialog(QWidget* parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags());
 
+    // renaming
     QString getBaseName() const {
         return ui.lineEdit->text();
     }
@@ -45,6 +46,31 @@ public:
         return ui.localeBox->isChecked();
     }
 
+    // replacement
+    bool getReplace() const {
+        return ui.relaceGroupBox->isChecked();
+    }
+    QString getFindStr() const {
+        return ui.findLineEdit->text();
+    }
+    QString getReplaceStr() const {
+        return ui.replaceLineEdit->text();
+    }
+    Qt::CaseSensitivity getCase() const {
+        return ui.caseBox->isChecked() ? Qt::CaseSensitive : Qt::CaseInsensitive;
+    }
+    bool getRegex() const {
+        return ui.regexBox->isChecked();
+    }
+
+    // case change
+    bool getCaseChange() const {
+        return ui.caseGroupBox->isChecked();
+    }
+    bool getUpperCase() const {
+        return ui.upperCaseButton->isChecked();
+    }
+
 protected:
     virtual void showEvent(QShowEvent* event) override;
 
@@ -56,6 +82,18 @@ class BulkRenamer {
 public:
     BulkRenamer(const Fm::FileInfoList& files, QWidget* parent = nullptr);
     ~BulkRenamer();
+
+private:
+    void rename(const Fm::FileInfoList& files,
+                QString& baseName, const QLocale& locale,
+                int start, bool zeroPadding, bool respectLocale,
+                QWidget* parent);
+    void renameByReplacing(const Fm::FileInfoList& files,
+                           const QString& findStr, const QString& replaceStr,
+                           Qt::CaseSensitivity cs, bool regex,
+                           QWidget* parent);
+    void renameByChangingCase(const Fm::FileInfoList& files, const QLocale& locale,
+                              bool toUpperCase, QWidget* parent);
 };
 
 }

--- a/pcmanfm/bulkrename.h
+++ b/pcmanfm/bulkrename.h
@@ -48,7 +48,7 @@ public:
 
     // replacement
     bool getReplace() const {
-        return ui.relaceGroupBox->isChecked();
+        return ui.replaceGroupBox->isChecked();
     }
     QString getFindStr() const {
         return ui.findLineEdit->text();


### PR DESCRIPTION
With regular expressions, capturing groups are automatically supported (by Qt); for example, with `([^\s]+)\s+([^\s]+)` as the text and `\2 \1` as the replacement, `this that` becomes `that this`.

Also, locale-aware case change is supported.

Closes https://github.com/lxqt/pcmanfm-qt/issues/1888