### PR TITLE
Show bulk rename dialog again on failure

### DIFF
--- a/pcmanfm/bulk-rename.ui
+++ b/pcmanfm/bulk-rename.ui
@@ -5,91 +5,81 @@
   <property name="windowTitle">
    <string>Bulk Rename</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="3">
-    <widget class="QLabel" name="mainLabel">
-     <property name="text">
-      <string>Rename selected files to:</string>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="serialGroupBox">
+     <property name="title">
+      <string>Serial Renaming</string>
      </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLineEdit" name="lineEdit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Name#</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="startLabel">
+          <property name="text">
+           <string># will be replaced by numbers starting with:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spinBox">
+          <property name="minimum">
+           <number>-1000</number>
+          </property>
+          <property name="maximum">
+           <number>1000</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>5</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="zeroBox">
+        <property name="text">
+         <string>Pad numbers with zero if possible</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="localeBox">
+        <property name="text">
+         <string>Use localized numbers</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="1" column="0" colspan="3">
-    <widget class="QLineEdit" name="lineEdit">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Name#</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="startLabel">
-     <property name="text">
-      <string># will be replaced by numbers starting with:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QSpinBox" name="spinBox">
-     <property name="minimum">
-      <number>-1000</number>
-     </property>
-     <property name="maximum">
-      <number>1000</number>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::MinimumExpanding</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>5</width>
-       <height>5</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="0" colspan="3">
-    <widget class="QCheckBox" name="zeroBox">
-     <property name="text">
-      <string>Pad numbers with zero if possible</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="3">
-    <widget class="QCheckBox" name="localeBox">
-     <property name="text">
-      <string>Use localized numbers</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>5</width>
-       <height>5</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="6" column="0" colspan="3">
+   <item>
     <widget class="QGroupBox" name="replaceGroupBox">
      <property name="title">
       <string>Replacement</string>
@@ -138,7 +128,7 @@
      </layout>
     </widget>
    </item>
-   <item row="7" column="0" colspan="3">
+   <item>
     <widget class="QGroupBox" name="caseGroupBox">
      <property name="title">
       <string>Change Case</string>
@@ -149,7 +139,7 @@
      <property name="checked">
       <bool>false</bool>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
        <widget class="QRadioButton" name="upperCaseButton">
         <property name="text">
@@ -170,7 +160,7 @@
      </layout>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item>
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -186,7 +176,7 @@
      </property>
     </spacer>
    </item>
-   <item row="9" column="0" colspan="3">
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>

--- a/pcmanfm/bulkrename.h
+++ b/pcmanfm/bulkrename.h
@@ -71,6 +71,12 @@ public:
         return ui.upperCaseButton->isChecked();
     }
 
+    void setState(const QString& baseName,
+                  const QString& findStr, const QString& replaceStr,
+                  bool replacement, bool caseChange,
+                  bool zeroPadding, bool respectLocale, bool regex, bool toUpperCase,
+                  int start, Qt::CaseSensitivity cs);
+
 protected:
     virtual void showEvent(QShowEvent* event) override;
 
@@ -84,15 +90,15 @@ public:
     ~BulkRenamer();
 
 private:
-    void rename(const Fm::FileInfoList& files,
+    bool rename(const Fm::FileInfoList& files,
                 QString& baseName, const QLocale& locale,
                 int start, bool zeroPadding, bool respectLocale,
                 QWidget* parent);
-    void renameByReplacing(const Fm::FileInfoList& files,
+    bool renameByReplacing(const Fm::FileInfoList& files,
                            const QString& findStr, const QString& replaceStr,
                            Qt::CaseSensitivity cs, bool regex,
                            QWidget* parent);
-    void renameByChangingCase(const Fm::FileInfoList& files, const QLocale& locale,
+    bool renameByChangingCase(const Fm::FileInfoList& files, const QLocale& locale,
                               bool toUpperCase, QWidget* parent);
 };
 


### PR DESCRIPTION
A failure means one of these: (1) nothing is renamed, (2) an empty string is searched, or (3) an invalid regex is searched. Then the dialog will be shown again with its previous state, after the error message is closed.

Also, as a compromise between different opinions, a group-box is added and all group-boxes are made mutually exclusive. This also simplifies the code a little.