### PR TITLE
Fixed shortcut removal with multiple desktops

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -853,11 +853,15 @@ void Application::updateFromSettings() {
     }
 }
 
-void Application::updateDesktopsFromSettings(bool changeSlide) {
+void Application::updateDesktopsFromSettings(bool changeSlide, bool allowShortcutRemoval) {
+// Desktop shortcuts should be removed only explicitly (e.g., through the Preferences dialog)
+// and only for the first desktop, not when desktops are created or a general setting changes.
     QVector<DesktopWindow*>::iterator it;
     for(it = desktopWindows_.begin(); it != desktopWindows_.end(); ++it) {
         DesktopWindow* desktopWin = static_cast<DesktopWindow*>(*it);
-        desktopWin->updateFromSettings(settings_, changeSlide);
+        desktopWin->updateFromSettings(settings_,
+                                       changeSlide,
+                                       allowShortcutRemoval && it == desktopWindows_.begin());
     }
 }
 

--- a/pcmanfm/application.h
+++ b/pcmanfm/application.h
@@ -98,7 +98,7 @@ public:
     }
 
     void updateFromSettings();
-    void updateDesktopsFromSettings(bool changeSlide = true);
+    void updateDesktopsFromSettings(bool changeSlide = true, bool allowShortcutRemoval = false);
 
     void openFolderInTerminal(Fm::FilePath path);
     void openFolders(Fm::FileInfoList files);

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -234,12 +234,14 @@ void DesktopPreferencesDialog::applySettings()
 void DesktopPreferencesDialog::onApplyClicked()
 {
   applySettings();
-  static_cast<Application*>(qApp)->updateDesktopsFromSettings();
+  static_cast<Application*>(qApp)->updateDesktopsFromSettings(true, // change slide
+                                                              true); // allow shortcut removal
 }
 
 void DesktopPreferencesDialog::accept() {
   applySettings();
-  static_cast<Application*>(qApp)->updateDesktopsFromSettings(false); // don't change slide wallpaper on clicking OK
+  static_cast<Application*>(qApp)->updateDesktopsFromSettings(false, // do not change slide
+                                                              true); // allow shortcut removal
   QDialog::accept();
 }
 

--- a/pcmanfm/desktopwindow.h
+++ b/pcmanfm/desktopwindow.h
@@ -74,7 +74,7 @@ public:
     void updateWallpaper(bool checkMTime = false);
     bool pickWallpaper();
     void nextWallpaper();
-    void updateFromSettings(Settings& settings, bool changeSlide = true);
+    void updateFromSettings(Settings& settings, bool changeSlide = true, bool allowShortcutRemoval = false);
 
     void queueRelayout(int delay = 0);
 
@@ -159,7 +159,7 @@ private:
                          const std::set<std::string>& draggedFiles = std::set<std::string>{});
     static void alignToGrid(QPoint& pos, const QPoint& topLeft, const QSize& grid, const int spacing);
 
-    void updateShortcutsFromSettings(Settings& settings);
+    void updateShortcutsFromSettings(Settings& settings, bool allowShortcutRemoval);
     void createTrashShortcut(int items);
     void createHomeShortcut();
     void createComputerShortcut();


### PR DESCRIPTION
With multiple desktops, if shortcuts were removed, error dialogs would be shown. The reason was that the shortcuts were removed in the first instance of desktop with a delay, and the code tried to remove them again in the other instances.

The problem didn't surface until each Wayland screen was given a separate desktop — on X11, there's only one extended desktop.

Fixes https://github.com/lxqt/pcmanfm-qt/issues/2059