### PR TITLE
Prevent an imminent crash after removing a Wayland screen

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -992,7 +992,8 @@ void Application::onScreenRemoved(QScreen* oldScreen) {
             int n = desktopWindows_.size();
             for(int i = 0; i < n; ++i) {
                 DesktopWindow* window = desktopWindows_.at(i);
-                if(window->getDesktopScreen() == oldScreen) {
+                auto desktopScr = window->getDesktopScreen();
+                if(desktopScr == nullptr || desktopScr == oldScreen) {
                     desktopWindows_.remove(i);
                     delete window;
                     break;


### PR DESCRIPTION
Qt → `QWindowSystemInterface::handleScreenRemoved` removes the screen from the list `qApp->screens()` before emitting `qApp->screenRemoved`. Therefore, a nullity check should be added to the code. It's also safe under X11.