### PR TITLE
An option to disable file tooltips on desktop

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -664,6 +664,13 @@ are left clicked, even when it is not the default file manager.</string>
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="noItemTooltip">
+         <property name="text">
+          <string>Do not show file tooltips</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -144,6 +144,8 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
 
   ui.allSticky->setChecked(settings.allSticky());
 
+  ui.noItemTooltip->setChecked(settings.desktopNoTooltip());
+
   resize(sizeHint()); // show it compact
 }
 
@@ -227,6 +229,8 @@ void DesktopPreferencesDialog::applySettings()
   settings.setOpenWithDefaultFileManager(ui.defaultFileManager->isChecked());
 
   settings.setAllSticky(ui.allSticky->isChecked());
+
+  settings.setDesktopNoTooltip(ui.noItemTooltip->isChecked());
 
   settings.save();
 }

--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -1993,6 +1993,11 @@ bool DesktopWindow::eventFilter(QObject* watched, QEvent* event) {
             // remove the drop indicator on leaving the widget during DND
             dropRect_ = QRect();
             break;
+        case QEvent::ToolTip:
+            if(static_cast<Application*>(qApp)->settings().desktopNoTooltip()) {
+                return true;
+            }
+            break;
         default:
             break;
         }

--- a/pcmanfm/settings.cpp
+++ b/pcmanfm/settings.cpp
@@ -84,6 +84,7 @@ Settings::Settings():
     desktopSortColumn_(Fm::FolderModel::ColumnFileMTime),
     desktopSortFolderFirst_(true),
     desktopSortHiddenLast_(false),
+    desktopNoTooltip_(false),
     alwaysShowTabs_(true),
     showTabClose_(true),
     switchToNewTab_(false),
@@ -269,6 +270,7 @@ bool Settings::loadFile(QString filePath) {
     desktopSortColumn_ = sortColumnFromString(settings.value(QStringLiteral("SortColumn")).toString());
     desktopSortFolderFirst_ = settings.value(QStringLiteral("SortFolderFirst"), true).toBool();
     desktopSortHiddenLast_ = settings.value(QStringLiteral("SortHiddenLast"), false).toBool();
+    desktopNoTooltip_ = settings.value(QStringLiteral("NoItemTooltip"), false).toBool();
 
     desktopCellMargins_ = (settings.value(QStringLiteral("DesktopCellMargins"), QSize(3, 1)).toSize()
                            .expandedTo(QSize(0, 0))).boundedTo(QSize(48, 48));
@@ -427,6 +429,7 @@ bool Settings::saveFile(QString filePath) {
     settings.setValue(QStringLiteral("SortColumn"), QString::fromUtf8(sortColumnToString(desktopSortColumn_)));
     settings.setValue(QStringLiteral("SortFolderFirst"), desktopSortFolderFirst_);
     settings.setValue(QStringLiteral("SortHiddenLast"), desktopSortHiddenLast_);
+    settings.setValue(QStringLiteral("NoItemTooltip"), desktopNoTooltip_);
     settings.setValue(QStringLiteral("DesktopCellMargins"), desktopCellMargins_);
     QList<QVariant> l{workAreaMargins_.left(),
                       workAreaMargins_.top(),

--- a/pcmanfm/settings.h
+++ b/pcmanfm/settings.h
@@ -439,6 +439,14 @@ public:
         desktopSortHiddenLast_ = desktopHiddenLast;
     }
 
+    bool desktopNoTooltip() const {
+        return desktopNoTooltip_;
+    }
+
+    void setDesktopNoTooltip(bool noTooltip) {
+        desktopNoTooltip_ = noTooltip;
+    }
+
     bool alwaysShowTabs() const {
         return alwaysShowTabs_;
     }
@@ -1100,6 +1108,7 @@ private:
     Fm::FolderModel::ColumnId desktopSortColumn_;
     bool desktopSortFolderFirst_;
     bool desktopSortHiddenLast_;
+    bool desktopNoTooltip_;
 
     bool alwaysShowTabs_;
     bool showTabClose_;


### PR DESCRIPTION
It's added to Advanced. No new translatable string is added.

Closes https://github.com/lxqt/pcmanfm-qt/issues/2065