### PR TITLE
Set the icon to pcmanfm-qt.svg via xdg_toplevel_icon

### DIFF
--- a/pcmanfm/main-win.ui
+++ b/pcmanfm/main-win.ui
@@ -14,7 +14,7 @@
    <string>File Manager</string>
   </property>
   <property name="windowIcon">
-   <iconset theme="folder">
+   <iconset theme="pcmanfm-qt">
     <normaloff>.</normaloff>.</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">


### PR DESCRIPTION
Set the icon to pcmanfm-qt.svg via xdg-toplevel-icon to achieve a uniform icon for both APPID and top-level-icon.