### PR TITLE
cmake: fix build with Qt 6.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ find_package(fm-qt6 ${LIBFMQT_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt2-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 find_package(LayerShellQt ${SHELLQT_MINIMUM_VERSION} REQUIRED)
 
+if (Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0")
+    find_package(Qt6GuiPrivate REQUIRED)
+endif()
+
 message(STATUS "Building ${PROJECT_NAME} with Qt ${Qt6Core_VERSION}")
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)


### PR DESCRIPTION
The 'Qt6FooPrivate' targets have been split into separate CMake files in Qt 6.9, and require a 'find_package(Qt6FooPrivate)' call starting with Qt 6.10.

See also: https://bugreports.qt.io/browse/QTBUG-87776