### PR TITLE
add --select compatibility flag

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -210,6 +210,9 @@ bool Application::parseCommandLineArgs() {
     QCommandLineOption findFilesOption(QStringList() << QStringLiteral("f") << QStringLiteral("find-files"), tr("Open Find Files utility"));
     parser.addOption(findFilesOption);
 
+    QCommandLineOption selectURIOption(QStringList() << QStringLiteral("s") << QStringLiteral("select"), tr("Select specified URI in parent folder"), tr("URI"));
+    parser.addOption(selectURIOption);
+
     QCommandLineOption setWallpaperOption(QStringList() << QStringLiteral("w") << QStringLiteral("set-wallpaper"), tr("Set desktop wallpaper from image FILE"), tr("FILE"));
     parser.addOption(setWallpaperOption);
 
@@ -262,6 +265,13 @@ bool Application::parseCommandLineArgs() {
             findFiles(parser.positionalArguments());
             keepRunning = true;
         }
+        else if (parser.isSet(selectURIOption)) {
+            QStringList uriList = parser.values(selectURIOption);
+            if (parser.isSet(selectURIOption)) {
+                ShowItems(uriList, QString()); // empty startupId
+            }
+            keepRunning = true;
+        }
         else if(parser.isSet(showPrefOption)) { // preferences dialog
             preferences(parser.value(showPrefOption));
             keepRunning = true;
@@ -308,6 +318,10 @@ bool Application::parseCommandLineArgs() {
         }
         else if(parser.isSet(findFilesOption)) { // file searching utility
             iface.call(QStringLiteral("findFiles"), parser.positionalArguments());
+        }
+        else if (parser.isSet(selectURIOption)) {
+            QStringList uriList = parser.values(selectURIOption);
+            iface.call(QStringLiteral("ShowItems"), uriList, QString());
         }
         else if(parser.isSet(showPrefOption)) { // preferences dialog
             iface.call(QStringLiteral("preferences"), parser.value(showPrefOption));


### PR DESCRIPTION
Some scripts rely on the `--select` flag to highlight files in file managers. While `caja`, `dolphin`, and `nautilus` support this flag, `pcmanfm-qt` currently does not.

Currently, `pcmanfm-qt` triggers an argument parser error when using --select, and if not, it open the file with the user selected mime app.

---

This simple PR adds support for the `--select` flag in `pcmanfm-qt` using the already existing `Application::ShowItems method`.

With this change, `--select` will be accepted by `pcmanfm-qt` without errors, improving compatibility with scripts expecting this flag.