### PR TITLE
Fixed showing of ampersand in recent files menu

### DIFF
--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -801,17 +801,16 @@ void MainWindow::updateRecenMenu() {
     int w = 150 * metrics.horizontalAdvance(QLatin1Char(' ')); // for eliding long texts
     for(int i = 0; i < recentNumber; ++i) {
         if(i < recentSize) {
-            auto fileName = recentFiles.at(i);
-            actions.at(i)->setText(metrics.elidedText(fileName, Qt::ElideMiddle, w));
+            actions.at(i)->setText(metrics.elidedText(recentFiles.value(i).replace(QLatin1Char('&'), QLatin1String("&&")).replace(QLatin1Char('\t'), QLatin1Char(' ')), Qt::ElideMiddle, w));
             QIcon icon;
-            auto mimeType = Fm::MimeType::guessFromFileName(fileName.toLocal8Bit().constData());
+            auto mimeType = Fm::MimeType::guessFromFileName(recentFiles.at(i).toLocal8Bit().constData());
             if(!mimeType->isUnknownType()) {
                 if(auto icn = mimeType->icon()) {
                     icon = icn->qicon();
                 }
             }
             actions.at(i)->setIcon(icon);
-            actions.at(i)->setData(fileName);
+            actions.at(i)->setData(recentFiles.at(i));
             actions.at(i)->setVisible(true);
         }
         else {


### PR DESCRIPTION
Previously, ampersands in file names inside the recent menu were left to Qt, resulting in underlines or nothing, depending on the widget style.