### PR TITLE
Small code cleanups (Qt5 -> Qt6)

### DIFF
--- a/pcmanfm/application.cpp
+++ b/pcmanfm/application.cpp
@@ -933,7 +933,7 @@ bool Application::nativeEventFilter(const QByteArray& eventType, void* message, 
         // filter all native X11 events (xcb)
         xcb_generic_event_t* generic_event = reinterpret_cast<xcb_generic_event_t*>(message);
         // qDebug("XCB event: %d", generic_event->response_type & ~0x80);
-        Q_FOREACH(DesktopWindow* window, desktopWindows_) {
+        for(DesktopWindow* window : desktopWindows_) {
         }
     }
     return false;

--- a/pcmanfm/connectserverdialog.cpp
+++ b/pcmanfm/connectserverdialog.cpp
@@ -16,8 +16,7 @@ ConnectServerDialog::ConnectServerDialog(QWidget *parent): QDialog(parent) {
 
   ui.setupUi(this);
 
-  connect(ui.serverType, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-          this, &ConnectServerDialog::onCurrentIndexChanged);
+  connect(ui.serverType, &QComboBox::currentIndexChanged, this, &ConnectServerDialog::onCurrentIndexChanged);
 
   connect(ui.host, &QLineEdit::textChanged, this, &ConnectServerDialog::checkInput);
   connect(ui.userName, &QLineEdit::textChanged, this, &ConnectServerDialog::checkInput);

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -51,7 +51,7 @@ DesktopPreferencesDialog::DesktopPreferencesDialog(QWidget* parent, Qt::WindowFl
   ui.setupUi(this);
 
   // setup wallpaper modes
-  connect(ui.wallpaperMode, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &DesktopPreferencesDialog::onWallpaperModeChanged);
+  connect(ui.wallpaperMode, &QComboBox::currentIndexChanged, this, &DesktopPreferencesDialog::onWallpaperModeChanged);
   ui.wallpaperMode->addItem(tr("Fill with background color only"), DesktopWindow::WallpaperNone);
   ui.wallpaperMode->addItem(tr("Stretch to fill the entire screen"), DesktopWindow::WallpaperStretch);
   ui.wallpaperMode->addItem(tr("Stretch to fit the screen"), DesktopWindow::WallpaperFit);
@@ -171,10 +171,10 @@ void DesktopPreferencesDialog::lockMargins(bool lock) {
   ui.vMargin->setDisabled(lock);
   if(lock) {
     ui.vMargin->setValue(ui.hMargin->value());
-    connect(ui.hMargin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), ui.vMargin, &QSpinBox::setValue);
+    connect(ui.hMargin, &QSpinBox::valueChanged, ui.vMargin, &QSpinBox::setValue);
   }
   else
-    disconnect(ui.hMargin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), ui.vMargin, &QSpinBox::setValue);
+    disconnect(ui.hMargin, &QSpinBox::valueChanged, ui.vMargin, &QSpinBox::setValue);
 }
 
 void DesktopPreferencesDialog::applySettings()

--- a/pcmanfm/preferencesdialog.cpp
+++ b/pcmanfm/preferencesdialog.cpp
@@ -534,10 +534,10 @@ void PreferencesDialog::lockMargins(bool lock) {
     ui.vMargin->setDisabled(lock);
     if(lock) {
         ui.vMargin->setValue(ui.hMargin->value());
-        connect(ui.hMargin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), ui.vMargin, &QSpinBox::setValue);
+        connect(ui.hMargin, &QSpinBox::valueChanged, ui.vMargin, &QSpinBox::setValue);
     }
     else {
-        disconnect(ui.hMargin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), ui.vMargin, &QSpinBox::setValue);
+        disconnect(ui.hMargin, &QSpinBox::valueChanged, ui.vMargin, &QSpinBox::setValue);
     }
 }
 


### PR DESCRIPTION
- Replace `Q_FOREACH`
- Rely on Qt6 disambiguated signals/slots