### PR TITLE
Assign rename file dialog to the parent window

### DIFF
--- a/pcmanfm/desktopwindow.cpp
+++ b/pcmanfm/desktopwindow.cpp
@@ -1733,7 +1733,7 @@ void DesktopWindow::onRenameActivated() {
     auto files = selectedFiles();
     if(!files.empty()) {
         for(auto& info: files) {
-            if(!Fm::renameFile(info, nullptr)) {
+            if(!Fm::renameFile(info, this)) {
                 break;
             }
         }

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -1887,7 +1887,7 @@ void MainWindow::on_actionRename_triggered() {
     }
     if(!files.empty()) {
         for(auto& file: files) {
-            if(!Fm::renameFile(file, nullptr)) {
+            if(!Fm::renameFile(file, this)) {
                 break;
             }
         }


### PR DESCRIPTION
This ensures that the dialog is attached to the main window.