### PR TITLE
Make dialogs as modal only for the window

### DIFF
--- a/pcmanfm/bulkrename.cpp
+++ b/pcmanfm/bulkrename.cpp
@@ -120,6 +120,7 @@ BulkRenamer::BulkRenamer(const Fm::FileInfoList& files, QWidget* parent) {
     bool showDlg = true;
     while(showDlg) {
         BulkRenameDialog dlg(parent);
+        dlg.setWindowModality(Qt::WindowModal);
         dlg.setState(baseName,
                      findStr, replaceStr,
                      replacement, caseChange,

--- a/pcmanfm/desktoppreferencesdialog.cpp
+++ b/pcmanfm/desktoppreferencesdialog.cpp
@@ -271,6 +271,7 @@ void DesktopPreferencesDialog::onBrowseClicked() {
 
   // use LXQt file dialog directly to set its view to thumbnail mode
   Fm::FileDialog dlg(this);
+  dlg.setWindowModality(Qt::WindowModal);
   dlg.resize(settings.wallpaperDialogSize());
   dlg.setSplitterPos(settings.wallpaperDialogSplitterPos());
   dlg.setAcceptMode(QFileDialog::AcceptOpen);
@@ -318,6 +319,7 @@ void DesktopPreferencesDialog::onBrowseClicked() {
 
 void DesktopPreferencesDialog::onFolderBrowseClicked() {
   QFileDialog dlg(this);
+  dlg.setWindowModality(Qt::WindowModal);
   dlg.setAcceptMode(QFileDialog::AcceptOpen);
   dlg.setFileMode(QFileDialog::Directory);
   dlg.setOption(QFileDialog::ShowDirsOnly);
@@ -344,7 +346,7 @@ void DesktopPreferencesDialog::onFolderBrowseClicked() {
 void DesktopPreferencesDialog::onBrowseDesktopFolderClicked()
 {
   QFileDialog dlg(this);
-  dlg.setAcceptMode(QFileDialog::AcceptOpen);
+  dlg.setWindowModality(Qt::WindowModal);
   dlg.setAcceptMode(QFileDialog::AcceptOpen);
   dlg.setFileMode(QFileDialog::Directory);
   dlg.setOption(QFileDialog::ShowDirsOnly);

--- a/pcmanfm/mainwindow.cpp
+++ b/pcmanfm/mainwindow.cpp
@@ -1226,6 +1226,7 @@ void MainWindow::on_actionAbout_triggered() {
         Ui::AboutDialog ui;
     };
     AboutDialog dialog(this);
+    dialog.setWindowModality(Qt::WindowModal);
     dialog.exec();
 }
 
@@ -1244,6 +1245,7 @@ void MainWindow::on_actionHiddenShortcuts_triggered() {
         Ui::HiddenShortcutsDialog ui;
     };
     HiddenShortcutsDialog dialog(this);
+    dialog.setWindowModality(Qt::WindowModal);
     dialog.exec();
 }
 


### PR DESCRIPTION
Without this, the dialogs block all opened windows of the application, not just the parent window.