### PR TITLE
Change "Slide Show" to "Slideshow" with updated translations

### DIFF
--- a/pcmanfm/desktop-preferences.ui
+++ b/pcmanfm/desktop-preferences.ui
@@ -470,13 +470,13 @@ are left clicked, even when it is not the default file manager.</string>
      </widget>
      <widget class="QWidget" name="slidePage">
       <attribute name="title">
-       <string>Slide Show</string>
+       <string>Slideshow</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
         <widget class="QGroupBox" name="slideShow">
          <property name="title">
-          <string>Enable Slide Show</string>
+          <string>Enable Slideshow</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -584,7 +584,7 @@ are left clicked, even when it is not the default file manager.</string>
           <item row="3" column="0" colspan="6">
            <widget class="QCheckBox" name="randomize">
             <property name="text">
-             <string>Randomize the slide show</string>
+             <string>Randomize the slideshow</string>
             </property>
            </widget>
           </item>

--- a/pcmanfm/translations/pcmanfm-qt.ts
+++ b/pcmanfm/translations/pcmanfm-qt.ts
@@ -524,12 +524,12 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
+        <source>Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
+        <source>Enable Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -568,6 +568,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -575,11 +580,6 @@ are left clicked, even when it is not the default file manager.</source>
     <message>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt_ar.ts
+++ b/pcmanfm/translations/pcmanfm-qt_ar.ts
@@ -550,13 +550,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>عرض الشرائح</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">عرض الشرائح</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>فعّل عرض الشرائح</translation>
+        <translation type="vanished">فعّل عرض الشرائح</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -594,6 +602,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> دق</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>عدم إظهار تلميحات الملف</translation>
@@ -604,9 +617,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>مجلد الخلفيات</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>عرض الشرائح عشوائي</translation>
+        <translation type="vanished">عرض الشرائح عشوائي</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_arn.ts
+++ b/pcmanfm/translations/pcmanfm-qt_arn.ts
@@ -524,12 +524,12 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
+        <source>Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
+        <source>Enable Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -568,6 +568,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -575,11 +580,6 @@ are left clicked, even when it is not the default file manager.</source>
     <message>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt_ast.ts
+++ b/pcmanfm/translations/pcmanfm-qt_ast.ts
@@ -524,12 +524,12 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
+        <source>Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
+        <source>Enable Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -568,6 +568,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -575,11 +580,6 @@ are left clicked, even when it is not the default file manager.</source>
     <message>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt_bg.ts
+++ b/pcmanfm/translations/pcmanfm-qt_bg.ts
@@ -550,13 +550,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Автоматична смяна</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Автоматична смяна</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Активиране на автоматична смяна</translation>
+        <translation type="vanished">Активиране на автоматична смяна</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -594,6 +602,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> минута (и)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Без показване на подсказките на файловете</translation>
@@ -604,9 +617,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>Папка с изображения за тапета</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Автоматична смяна на изображенията в случаен ред</translation>
+        <translation type="vanished">Автоматична смяна на изображенията в случаен ред</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_ca.ts
+++ b/pcmanfm/translations/pcmanfm-qt_ca.ts
@@ -553,13 +553,21 @@ el gestor de fitxers predeterminat.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Presentació de diapositives</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Presentació de diapositives</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Habilita la presentació de diapositives</translation>
+        <translation type="vanished">Habilita la presentació de diapositives</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -597,6 +605,11 @@ el gestor de fitxers predeterminat.</translation>
         <translation> minut(s)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>No mostris informació emergent de fitxers</translation>
@@ -607,9 +620,8 @@ el gestor de fitxers predeterminat.</translation>
         <translation>Carpeta del fons d&apos;escriptori</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Aleatoritza la presentació de diapositives</translation>
+        <translation type="vanished">Aleatoritza la presentació de diapositives</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_cs.ts
+++ b/pcmanfm/translations/pcmanfm-qt_cs.ts
@@ -552,13 +552,21 @@ kliknete levým tlačítkem, i když to není výchozí správce souborů.</tran
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Prezentace</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Prezentace</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Měnit obrázky na pozadí</translation>
+        <translation type="vanished">Měnit obrázky na pozadí</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ kliknete levým tlačítkem, i když to není výchozí správce souborů.</tran
         <translation> minuty</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Neukazovat nástrojové rady k souborům</translation>
@@ -606,9 +619,8 @@ kliknete levým tlačítkem, i když to není výchozí správce souborů.</tran
         <translation>Složka s obrázky na plochu</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Náhodné pořadí prezentace</translation>
+        <translation type="vanished">Náhodné pořadí prezentace</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_cy.ts
+++ b/pcmanfm/translations/pcmanfm-qt_cy.ts
@@ -524,13 +524,13 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation></translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
-        <translation></translation>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -568,6 +568,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -575,11 +580,6 @@ are left clicked, even when it is not the default file manager.</source>
     <message>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
         <translation></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt_da.ts
+++ b/pcmanfm/translations/pcmanfm-qt_da.ts
@@ -552,13 +552,21 @@ venstreklikkes på dem, selv hvis den ikke er defineret som standardfilhåndteri
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Diasshow</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Diasshow</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Aktivér diasshow</translation>
+        <translation type="vanished">Aktivér diasshow</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ venstreklikkes på dem, selv hvis den ikke er defineret som standardfilhåndteri
         <translation> minut(ter)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Vis ikke værktøjstips for filer</translation>
@@ -606,9 +619,8 @@ venstreklikkes på dem, selv hvis den ikke er defineret som standardfilhåndteri
         <translation>Tapetmappe</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Tilfældiggør diasshowet</translation>
+        <translation type="vanished">Tilfældiggør diasshowet</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_de.ts
+++ b/pcmanfm/translations/pcmanfm-qt_de.ts
@@ -554,13 +554,21 @@ geöffnet, selbst wenn es nicht der Standard-Dateimanager ist.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Diashow</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Diashow</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Diashow aktivieren</translation>
+        <translation type="vanished">Diashow aktivieren</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -598,6 +606,11 @@ geöffnet, selbst wenn es nicht der Standard-Dateimanager ist.</translation>
         <translation> Minute(n)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Keine Kurzinfo zu Dateien anzeigen</translation>
@@ -608,9 +621,8 @@ geöffnet, selbst wenn es nicht der Standard-Dateimanager ist.</translation>
         <translation>Hintergrundbild-Ordner</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Zufällige Diashow</translation>
+        <translation type="vanished">Zufällige Diashow</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_el.ts
+++ b/pcmanfm/translations/pcmanfm-qt_el.ts
@@ -553,13 +553,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Διαπόραμα</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Διαπόραμα</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Ενεργοποίηση του διαποράματος</translation>
+        <translation type="vanished">Ενεργοποίηση του διαποράματος</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -597,6 +605,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> λεπτό(ά)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Να μην εμφανίζονται οι υποδείξεις αρχείων</translation>
@@ -607,9 +620,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>Φάκελος ταπετσαριών</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Τυχαιοποίηση των διαφανειών</translation>
+        <translation type="vanished">Τυχαιοποίηση των διαφανειών</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_en_GB.ts
+++ b/pcmanfm/translations/pcmanfm-qt_en_GB.ts
@@ -533,13 +533,13 @@ are left clicked, even when it is not the default file manager.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation></translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
-        <translation></translation>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -577,6 +577,11 @@ are left clicked, even when it is not the default file manager.</translation>
         <translation></translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished">Do not show file tooltips</translation>
@@ -587,9 +592,8 @@ are left clicked, even when it is not the default file manager.</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Randomise the slide show</translation>
+        <translation type="vanished">Randomise the slide show</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_eo.ts
+++ b/pcmanfm/translations/pcmanfm-qt_eo.ts
@@ -526,12 +526,12 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
+        <source>Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
+        <source>Enable Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -570,6 +570,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -577,11 +582,6 @@ are left clicked, even when it is not the default file manager.</source>
     <message>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt_es.ts
+++ b/pcmanfm/translations/pcmanfm-qt_es.ts
@@ -548,13 +548,21 @@ es el gestor de archivos predeterminado.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Pase de diapositivas</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Pase de diapositivas</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Activar el cambio de imagen automático</translation>
+        <translation type="vanished">Activar el cambio de imagen automático</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -592,6 +600,11 @@ es el gestor de archivos predeterminado.</translation>
         <translation> minuto(s)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished">No mostrar descripciones emergentes de archivos</translation>
@@ -602,9 +615,8 @@ es el gestor de archivos predeterminado.</translation>
         <translation>Carpeta de fondos de pantalla</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Cambio de imagenes aleatorio</translation>
+        <translation type="vanished">Cambio de imagenes aleatorio</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_es_VE.ts
+++ b/pcmanfm/translations/pcmanfm-qt_es_VE.ts
@@ -524,12 +524,12 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
+        <source>Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
+        <source>Enable Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -568,6 +568,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -575,11 +580,6 @@ are left clicked, even when it is not the default file manager.</source>
     <message>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt_et.ts
+++ b/pcmanfm/translations/pcmanfm-qt_et.ts
@@ -552,13 +552,21 @@ PCManFM-Qt rakendusega ka siis, kui ta pole vaikimisi failihaldur.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Slaidiseanss</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Slaidiseanss</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Luba slaidiseanss</translation>
+        <translation type="vanished">Luba slaidiseanss</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ PCManFM-Qt rakendusega ka siis, kui ta pole vaikimisi failihaldur.</translation>
         <translation> minut(it)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Ära näita failide teabemulle</translation>
@@ -606,9 +619,8 @@ PCManFM-Qt rakendusega ka siis, kui ta pole vaikimisi failihaldur.</translation>
         <translation>Taustapildi kaust</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Juhuslik slaidiseanss</translation>
+        <translation type="vanished">Juhuslik slaidiseanss</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_eu.ts
+++ b/pcmanfm/translations/pcmanfm-qt_eu.ts
@@ -533,13 +533,21 @@ ezkerreko klik egiten dira, fitxategi-kudeatzaile lehenetsia ez denean ere.</tra
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Diapositiba aurkezpena</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Diapositiba aurkezpena</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Gaitu diapositiba aurkezpena</translation>
+        <translation type="vanished">Gaitu diapositiba aurkezpena</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -577,6 +585,11 @@ ezkerreko klik egiten dira, fitxategi-kudeatzaile lehenetsia ez denean ere.</tra
         <translation> minutu(ak)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished">Ez erakutsi fitxategien argibideak</translation>
@@ -585,11 +598,6 @@ ezkerreko klik egiten dira, fitxategi-kudeatzaile lehenetsia ez denean ere.</tra
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
         <translation>Horma-paperaren karpeta</translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_fi.ts
+++ b/pcmanfm/translations/pcmanfm-qt_fi.ts
@@ -552,13 +552,21 @@ klikattiin, vaikka se ei olisi oletustiedostonhallintaohjelma.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Diaesitys</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Diaesitys</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Käytä diaesitystä</translation>
+        <translation type="vanished">Käytä diaesitystä</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ klikattiin, vaikka se ei olisi oletustiedostonhallintaohjelma.</translation>
         <translation> minuuttia</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Älä näytä työkaluvihjettä tiedostoille</translation>
@@ -606,9 +619,8 @@ klikattiin, vaikka se ei olisi oletustiedostonhallintaohjelma.</translation>
         <translation>Taustakuvan kansio</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Satunnaista diaesitys</translation>
+        <translation type="vanished">Satunnaista diaesitys</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_fil.ts
+++ b/pcmanfm/translations/pcmanfm-qt_fil.ts
@@ -543,12 +543,12 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
+        <source>Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
+        <source>Enable Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -587,6 +587,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -594,11 +599,6 @@ are left clicked, even when it is not the default file manager.</source>
     <message>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt_fr.ts
+++ b/pcmanfm/translations/pcmanfm-qt_fr.ts
@@ -554,13 +554,21 @@ avec un clic gauche, même si aucun gestionnaire de fichiers n&apos;est défini 
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Diaporama</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Diaporama</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Activer le diaporama</translation>
+        <translation type="vanished">Activer le diaporama</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -598,6 +606,11 @@ avec un clic gauche, même si aucun gestionnaire de fichiers n&apos;est défini 
         <translation> minute(s)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished">Ne pas afficher les info-bulles de fichier</translation>
@@ -608,9 +621,8 @@ avec un clic gauche, même si aucun gestionnaire de fichiers n&apos;est défini 
         <translation>Dossier des fonds d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Défilement aléatoire des diapositives</translation>
+        <translation type="vanished">Défilement aléatoire des diapositives</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_ga.ts
+++ b/pcmanfm/translations/pcmanfm-qt_ga.ts
@@ -534,12 +534,12 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
+        <source>Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
+        <source>Enable Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -578,6 +578,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -585,11 +590,6 @@ are left clicked, even when it is not the default file manager.</source>
     <message>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt_gl.ts
+++ b/pcmanfm/translations/pcmanfm-qt_gl.ts
@@ -549,13 +549,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Diaporama</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Diaporama</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Activar o diaporama</translation>
+        <translation type="vanished">Activar o diaporama</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -593,6 +601,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> minuto(s)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished">Non amosar os consellos das ferramentas de ficheiro</translation>
@@ -603,9 +616,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>Cartafol de fondos de pantalla</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Pasar ao chou o diaporama</translation>
+        <translation type="vanished">Pasar ao chou o diaporama</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_he.ts
+++ b/pcmanfm/translations/pcmanfm-qt_he.ts
@@ -551,13 +551,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>מצגת</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">מצגת</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>הפעלת מצגת</translation>
+        <translation type="vanished">הפעלת מצגת</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -595,6 +603,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> דקה/ות</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>לא להציג תיבות צצות לקבצים</translation>
@@ -605,9 +618,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>תיקיית רקע</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>הרצת המצגת בסדר אקראי</translation>
+        <translation type="vanished">הרצת המצגת בסדר אקראי</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_hi.ts
+++ b/pcmanfm/translations/pcmanfm-qt_hi.ts
@@ -553,13 +553,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>स्लाइड प्रदर्शन</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">स्लाइड प्रदर्शन</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>स्लाइड प्रदर्शन सक्षम करें</translation>
+        <translation type="vanished">स्लाइड प्रदर्शन सक्षम करें</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -597,6 +605,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> मिनट</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished">फ़ाइल टूलटिप न दिखाएं</translation>
@@ -607,9 +620,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>वॉलपेपर फ़ोल्डर</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>स्लाइड प्रदर्शन को रैंडमाइज करें</translation>
+        <translation type="vanished">स्लाइड प्रदर्शन को रैंडमाइज करें</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_hr.ts
+++ b/pcmanfm/translations/pcmanfm-qt_hr.ts
@@ -553,13 +553,21 @@ upravljač datoteka.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Prezentacija</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Prezentacija</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Aktiviraj prezentaciju</translation>
+        <translation type="vanished">Aktiviraj prezentaciju</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -597,6 +605,11 @@ upravljač datoteka.</translation>
         <translation> min</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Ne prikazuj savjete u oblačiću</translation>
@@ -607,9 +620,8 @@ upravljač datoteka.</translation>
         <translation>Mapa slika pozadine</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Slučajni prikaz prezentacije</translation>
+        <translation type="vanished">Slučajni prikaz prezentacije</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_hu.ts
+++ b/pcmanfm/translations/pcmanfm-qt_hu.ts
@@ -545,13 +545,21 @@ ha bal gombbal kattintanak rájuk, még akkor is, ha az nem az alapértelmezett 
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Diavetítés</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Diavetítés</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Diavetítés bekapcsolása</translation>
+        <translation type="vanished">Diavetítés bekapcsolása</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -589,6 +597,11 @@ ha bal gombbal kattintanak rájuk, még akkor is, ha az nem az alapértelmezett 
         <translation> perc</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished">Ne mutassa a fájlok elemleírását</translation>
@@ -599,9 +612,8 @@ ha bal gombbal kattintanak rájuk, még akkor is, ha az nem az alapértelmezett 
         <translation>Mappa</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Véletlenszerű diavetítés</translation>
+        <translation type="vanished">Véletlenszerű diavetítés</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_id.ts
+++ b/pcmanfm/translations/pcmanfm-qt_id.ts
@@ -553,13 +553,21 @@ jika folder tersebut diklik kiri, walaupun PCManFM-Qt bukan file manager standar
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Tampilan Slide</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Tampilan Slide</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Aktifkan Tampilan Slide</translation>
+        <translation type="vanished">Aktifkan Tampilan Slide</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -597,6 +605,11 @@ jika folder tersebut diklik kiri, walaupun PCManFM-Qt bukan file manager standar
         <translation> menit</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Jangan tampilkan tooltip berkas</translation>
@@ -607,9 +620,8 @@ jika folder tersebut diklik kiri, walaupun PCManFM-Qt bukan file manager standar
         <translation>Folder kertas dinding</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Mengacak tampilan slide</translation>
+        <translation type="vanished">Mengacak tampilan slide</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_ie.ts
+++ b/pcmanfm/translations/pcmanfm-qt_ie.ts
@@ -526,13 +526,17 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Exhibition</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
+        <source>Enable Slideshow</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Exhibition</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -570,6 +574,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> minute(s)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -578,11 +587,6 @@ are left clicked, even when it is not the default file manager.</source>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
         <translation>Fólder de tapetes</translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_is.ts
+++ b/pcmanfm/translations/pcmanfm-qt_is.ts
@@ -536,13 +536,21 @@ vinstrismellt á þær, jafnvel þegar hann er ekki sjálfgefinn skráastjóri.<
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Skyggnusýning</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Skyggnusýning</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Virkja skyggnusýningu</translation>
+        <translation type="vanished">Virkja skyggnusýningu</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -580,6 +588,11 @@ vinstrismellt á þær, jafnvel þegar hann er ekki sjálfgefinn skráastjóri.<
         <translation> Mínút(a/ur)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -590,9 +603,8 @@ vinstrismellt á þær, jafnvel þegar hann er ekki sjálfgefinn skráastjóri.<
         <translation>Mappa með sjkáborðsmyndum</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Velja myndir af handahófi</translation>
+        <translation type="vanished">Velja myndir af handahófi</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_it.ts
+++ b/pcmanfm/translations/pcmanfm-qt_it.ts
@@ -552,13 +552,21 @@ sinistro anche se non è il gestore file predefinito.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Presentazione</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Presentazione</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Attiva la presentazione</translation>
+        <translation type="vanished">Attiva la presentazione</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ sinistro anche se non è il gestore file predefinito.</translation>
         <translation> minuto/i</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Non mostrare tooltip per i file</translation>
@@ -606,9 +619,8 @@ sinistro anche se non è il gestore file predefinito.</translation>
         <translation>Cartella sfondi desktop</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Presentazione casuale</translation>
+        <translation type="vanished">Presentazione casuale</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_ja.ts
+++ b/pcmanfm/translations/pcmanfm-qt_ja.ts
@@ -552,13 +552,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>スライドショー</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">スライドショー</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>スライドショーを有効にする</translation>
+        <translation type="vanished">スライドショーを有効にする</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> 分</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>ファイルのツールチップを表示しない</translation>
@@ -606,9 +619,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>壁紙のフォルダー</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>スライドショーをランダムに表示する</translation>
+        <translation type="vanished">スライドショーをランダムに表示する</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_ka.ts
+++ b/pcmanfm/translations/pcmanfm-qt_ka.ts
@@ -552,13 +552,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>სლაიდების ჩვენება</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">სლაიდების ჩვენება</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>სლაიდშოუს ჩართვა</translation>
+        <translation type="vanished">სლაიდშოუს ჩართვა</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> წუთი</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>ფაილის მინიშნებების არ-ჩვენება</translation>
@@ -606,9 +619,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>ფონის სურათის საქაღალდე</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>სლაიდშოუს შემთხვევითობა</translation>
+        <translation type="vanished">სლაიდშოუს შემთხვევითობა</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_kk.ts
+++ b/pcmanfm/translations/pcmanfm-qt_kk.ts
@@ -552,13 +552,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Слайдшоу</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Слайдшоу</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Слайдшоуды іске қосу</translation>
+        <translation type="vanished">Слайдшоуды іске қосу</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> минут</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Файлдың қалқымалы нұсқауларын көрсетпеу</translation>
@@ -606,9 +619,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>Тұсқағаз бумасы</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Слайдшоуды кездейсоқ ретпен қою</translation>
+        <translation type="vanished">Слайдшоуды кездейсоқ ретпен қою</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_ko.ts
+++ b/pcmanfm/translations/pcmanfm-qt_ko.ts
@@ -548,13 +548,21 @@ PCManFM-Qt에서 열립니다.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>슬라이드 쇼</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">슬라이드 쇼</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>슬라이드 쇼 활성화</translation>
+        <translation type="vanished">슬라이드 쇼 활성화</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -592,6 +600,11 @@ PCManFM-Qt에서 열립니다.</translation>
         <translation> 분</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>파일 툴팁 표시 안함</translation>
@@ -602,9 +615,8 @@ PCManFM-Qt에서 열립니다.</translation>
         <translation>배경화면 폴더</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>슬라이드 쇼 임의 재생</translation>
+        <translation type="vanished">슬라이드 쇼 임의 재생</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_lg.ts
+++ b/pcmanfm/translations/pcmanfm-qt_lg.ts
@@ -554,13 +554,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Ebifaananyi Ebyekyusa</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Ebifaananyi Ebyekyusa</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Ekifaananyi eky&apos;okubwaliriro kyekyusenga</translation>
+        <translation type="vanished">Ekifaananyi eky&apos;okubwaliriro kyekyusenga</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -598,6 +606,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> dakiika</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Tompanga magezi ku bya fayiro</translation>
@@ -608,9 +621,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>Tterekero omuli ebifaananyi eby&apos;oku bwaliriro</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Ebifaananyi bijjenga muwawa</translation>
+        <translation type="vanished">Ebifaananyi bijjenga muwawa</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_lt.ts
+++ b/pcmanfm/translations/pcmanfm-qt_lt.ts
@@ -553,13 +553,21 @@ numatytoji failų tvarkytuvė.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Skaidrių rodymas</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Skaidrių rodymas</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Įjungti skaidrių rodymą</translation>
+        <translation type="vanished">Įjungti skaidrių rodymą</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -597,6 +605,11 @@ numatytoji failų tvarkytuvė.</translation>
         <translation> minutė(-ių)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Nerodyti failų paaiškinimų</translation>
@@ -607,9 +620,8 @@ numatytoji failų tvarkytuvė.</translation>
         <translation>Darbalaukio fonų aplankas</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Atsitiktinė tvarka</translation>
+        <translation type="vanished">Atsitiktinė tvarka</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_lv.ts
+++ b/pcmanfm/translations/pcmanfm-qt_lv.ts
@@ -545,13 +545,17 @@ pat ja PCManFM-Qt nav noklusējuma failu pārvaldnieks.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Slaidrāde</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
+        <source>Enable Slideshow</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Slaidrāde</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -589,6 +593,11 @@ pat ja PCManFM-Qt nav noklusējuma failu pārvaldnieks.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -596,11 +605,6 @@ pat ja PCManFM-Qt nav noklusējuma failu pārvaldnieks.</translation>
     <message>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt_nb_NO.ts
+++ b/pcmanfm/translations/pcmanfm-qt_nb_NO.ts
@@ -552,13 +552,21 @@ venstreklikkes, selv når det ikke er forvalgt filbehandler.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Lysbildeshow</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Lysbildeshow</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Aktiver lysbildeshow</translation>
+        <translation type="vanished">Aktiver lysbildeshow</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ venstreklikkes, selv når det ikke er forvalgt filbehandler.</translation>
         <translation> minutte(r)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished">Ikke vis fil-verktøytips</translation>
@@ -606,9 +619,8 @@ venstreklikkes, selv når det ikke er forvalgt filbehandler.</translation>
         <translation>Skrivebordsbakgrunnsmappe</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Tilfeldig bilde i lysbildeshow</translation>
+        <translation type="vanished">Tilfeldig bilde i lysbildeshow</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_nl.ts
+++ b/pcmanfm/translations/pcmanfm-qt_nl.ts
@@ -551,13 +551,21 @@ zelfs als dat niet de standaard bestandsbeheerder is.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Diavoorstelling</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Diavoorstelling</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Diavoorstelling tonen</translation>
+        <translation type="vanished">Diavoorstelling tonen</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -595,6 +603,11 @@ zelfs als dat niet de standaard bestandsbeheerder is.</translation>
         <translation> minu(u)t(en)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Geen hulpballonnen van bestanden tonen</translation>
@@ -605,9 +618,8 @@ zelfs als dat niet de standaard bestandsbeheerder is.</translation>
         <translation>Map met bureaubladachtergrond</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Dia&apos;s in willekeurige volgorde tonen</translation>
+        <translation type="vanished">Dia&apos;s in willekeurige volgorde tonen</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_oc.ts
+++ b/pcmanfm/translations/pcmanfm-qt_oc.ts
@@ -526,12 +526,12 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
+        <source>Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
+        <source>Enable Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -570,6 +570,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -577,11 +582,6 @@ are left clicked, even when it is not the default file manager.</source>
     <message>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt_pl.ts
+++ b/pcmanfm/translations/pcmanfm-qt_pl.ts
@@ -552,13 +552,21 @@ są klikane lewym przyciskiem, nawet jeśli nie jest to domyślny menedżer plik
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Pokaz slajdów</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Pokaz slajdów</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Włącz pokaz slajdów</translation>
+        <translation type="vanished">Włącz pokaz slajdów</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ są klikane lewym przyciskiem, nawet jeśli nie jest to domyślny menedżer plik
         <translation> minut</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Nie pokazuj podpowiedzi dotyczących plików</translation>
@@ -606,9 +619,8 @@ są klikane lewym przyciskiem, nawet jeśli nie jest to domyślny menedżer plik
         <translation>Katalog z tapetami pulpitu</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Kolejność losowa</translation>
+        <translation type="vanished">Kolejność losowa</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_pt.ts
+++ b/pcmanfm/translations/pcmanfm-qt_pt.ts
@@ -552,13 +552,21 @@ se clicar com o botão esquerdo do rato - mesmo que este não seja o gestor de f
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Apresentação</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Apresentação</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Ativar apresentação</translation>
+        <translation type="vanished">Ativar apresentação</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ se clicar com o botão esquerdo do rato - mesmo que este não seja o gestor de f
         <translation> minuto(s)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Não mostrar dicas de ficheiros</translation>
@@ -606,9 +619,8 @@ se clicar com o botão esquerdo do rato - mesmo que este não seja o gestor de f
         <translation>Pasta do papel de parede</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Apresentação aleatória</translation>
+        <translation type="vanished">Apresentação aleatória</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_pt_BR.ts
+++ b/pcmanfm/translations/pcmanfm-qt_pt_BR.ts
@@ -552,13 +552,21 @@ clicadas com o botão esquerdo, mesmo quando não for o gerenciador de arquivos 
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Apresentação de slides</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Apresentação de slides</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Habilitar apresentação de slides</translation>
+        <translation type="vanished">Habilitar apresentação de slides</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ clicadas com o botão esquerdo, mesmo quando não for o gerenciador de arquivos 
         <translation> minuto(s)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished">Não exibir dicas de arquivo</translation>
@@ -606,9 +619,8 @@ clicadas com o botão esquerdo, mesmo quando não for o gerenciador de arquivos 
         <translation>Pasta de papel de parede</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Apresentação de slides aleatória</translation>
+        <translation type="vanished">Apresentação de slides aleatória</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_ro.ts
+++ b/pcmanfm/translations/pcmanfm-qt_ro.ts
@@ -552,13 +552,21 @@ sunt apăsate stânga, chiar și atunci când nu este managerul de fișiere impl
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Slide Show</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Slide Show</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Activați Slide-Show-ul</translation>
+        <translation type="vanished">Activați Slide-Show-ul</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ sunt apăsate stânga, chiar și atunci când nu este managerul de fișiere impl
         <translation> minut(e)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -606,9 +619,8 @@ sunt apăsate stânga, chiar și atunci când nu este managerul de fișiere impl
         <translation>Folderul Wallpaperul-ui</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Randomizați slide-show-ul</translation>
+        <translation type="vanished">Randomizați slide-show-ul</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_ru.ts
+++ b/pcmanfm/translations/pcmanfm-qt_ru.ts
@@ -550,13 +550,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Показ слайдов</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Показ слайдов</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Разрешить показ слайдов</translation>
+        <translation type="vanished">Разрешить показ слайдов</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -594,6 +602,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> мин.</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Не показывать всплывающие подсказки файлов</translation>
@@ -604,9 +617,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>Папка с обоями</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Случайный порядок слайдов</translation>
+        <translation type="vanished">Случайный порядок слайдов</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_si.ts
+++ b/pcmanfm/translations/pcmanfm-qt_si.ts
@@ -546,13 +546,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>ස්ලයිඩ පෙන්වීම</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">ස්ලයිඩ පෙන්වීම</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>ස්ලයිඩ පෙන්වීම සක්‍රිය කරන්න</translation>
+        <translation type="vanished">ස්ලයිඩ පෙන්වීම සක්‍රිය කරන්න</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -590,6 +598,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> මිනිත්තු</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -597,11 +610,6 @@ are left clicked, even when it is not the default file manager.</source>
     <message>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt_sk_SK.ts
+++ b/pcmanfm/translations/pcmanfm-qt_sk_SK.ts
@@ -553,13 +553,21 @@ kliknete ľavým tlačidlom myši, aj keď nejde o predvoleného správcu súbor
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Prezentovať</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Prezentovať</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Meniť obrázky na pozadí</translation>
+        <translation type="vanished">Meniť obrázky na pozadí</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -597,6 +605,11 @@ kliknete ľavým tlačidlom myši, aj keď nejde o predvoleného správcu súbor
         <translation> .minúty</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished">Nezobrazovať podrobnosti pri presunutí myši na súbor</translation>
@@ -607,9 +620,8 @@ kliknete ľavým tlačidlom myši, aj keď nejde o predvoleného správcu súbor
         <translation>Priečinok s tapetami</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Náhodné poradie, prezentácia</translation>
+        <translation type="vanished">Náhodné poradie, prezentácia</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_sl.ts
+++ b/pcmanfm/translations/pcmanfm-qt_sl.ts
@@ -534,12 +534,12 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
+        <source>Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
+        <source>Enable Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -578,6 +578,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -585,11 +590,6 @@ are left clicked, even when it is not the default file manager.</source>
     <message>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt_sv.ts
+++ b/pcmanfm/translations/pcmanfm-qt_sv.ts
@@ -552,13 +552,21 @@ vänsterklickas, även när den inte är standard filhanterare.</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Bildspel</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Bildspel</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Starta bildspel</translation>
+        <translation type="vanished">Starta bildspel</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ vänsterklickas, även när den inte är standard filhanterare.</translation>
         <translation> minuter</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Visa inte filverktygstips</translation>
@@ -606,9 +619,8 @@ vänsterklickas, även när den inte är standard filhanterare.</translation>
         <translation>Mapp för bakgrundsbilder</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Slumpa bildspelet</translation>
+        <translation type="vanished">Slumpa bildspelet</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_tr.ts
+++ b/pcmanfm/translations/pcmanfm-qt_tr.ts
@@ -553,13 +553,21 @@ olarak seçilmese bile sol tıklandığında PCManFM-Qt&apos;de açılır.</tran
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Slayt Gösterisi</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Slayt Gösterisi</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Slayt Gösterisini Etkinleştir</translation>
+        <translation type="vanished">Slayt Gösterisini Etkinleştir</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -597,6 +605,11 @@ olarak seçilmese bile sol tıklandığında PCManFM-Qt&apos;de açılır.</tran
         <translation> .dakika(lar)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Dosya araç ipuçlarını gösterme</translation>
@@ -607,9 +620,8 @@ olarak seçilmese bile sol tıklandığında PCManFM-Qt&apos;de açılır.</tran
         <translation>Duvar kağıdı dizini</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Duvar kağıdı rasgele seçilsin</translation>
+        <translation type="vanished">Duvar kağıdı rasgele seçilsin</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_ug.ts
+++ b/pcmanfm/translations/pcmanfm-qt_ug.ts
@@ -524,12 +524,12 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
+        <source>Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
-        <source>Enable Slide Show</source>
+        <source>Enable Slideshow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -568,6 +568,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished"></translation>
@@ -575,11 +580,6 @@ are left clicked, even when it is not the default file manager.</source>
     <message>
         <location filename="../desktop-preferences.ui" line="498"/>
         <source>Wallpaper folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
-        <source>Randomize the slide show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/pcmanfm/translations/pcmanfm-qt_uk.ts
+++ b/pcmanfm/translations/pcmanfm-qt_uk.ts
@@ -552,13 +552,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Слайд-шоу</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Слайд-шоу</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Увімкнути слайд-шоу</translation>
+        <translation type="vanished">Увімкнути слайд-шоу</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> хвилин(и)</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>Не показувати підказки для файлів</translation>
@@ -606,9 +619,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>Тека зоражень тла</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Випадковий порядок показу слайдів</translation>
+        <translation type="vanished">Випадковий порядок показу слайдів</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_vi.ts
+++ b/pcmanfm/translations/pcmanfm-qt_vi.ts
@@ -552,13 +552,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>Trình chiếu</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Trình chiếu</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>Bật Trình chiếu</translation>
+        <translation type="vanished">Bật Trình chiếu</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -596,6 +604,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> phút</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation type="unfinished">Không hiển thị chú giải cho tập tin</translation>
@@ -606,9 +619,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>Thư mục hình nền</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>Trình chiếu ngẫu nhiên</translation>
+        <translation type="vanished">Trình chiếu ngẫu nhiên</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_zh_CN.ts
+++ b/pcmanfm/translations/pcmanfm-qt_zh_CN.ts
@@ -549,13 +549,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>幻灯片放映</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">幻灯片放映</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>启用幻灯片播放</translation>
+        <translation type="vanished">启用幻灯片播放</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -593,6 +601,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> 分钟</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>不要显示文件信息提示</translation>
@@ -603,9 +616,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>墙纸文件夹</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>随机幻灯片放映</translation>
+        <translation type="vanished">随机幻灯片放映</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>

--- a/pcmanfm/translations/pcmanfm-qt_zh_TW.ts
+++ b/pcmanfm/translations/pcmanfm-qt_zh_TW.ts
@@ -553,13 +553,21 @@ are left clicked, even when it is not the default file manager.</source>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="473"/>
-        <source>Slide Show</source>
-        <translation>幻燈片播放</translation>
+        <source>Slideshow</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="479"/>
+        <source>Enable Slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">幻燈片播放</translation>
+    </message>
+    <message>
         <source>Enable Slide Show</source>
-        <translation>啟用幻燈片播放</translation>
+        <translation type="vanished">啟用幻燈片播放</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="491"/>
@@ -597,6 +605,11 @@ are left clicked, even when it is not the default file manager.</source>
         <translation> 分鐘</translation>
     </message>
     <message>
+        <location filename="../desktop-preferences.ui" line="587"/>
+        <source>Randomize the slideshow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../desktop-preferences.ui" line="666"/>
         <source>Do not show file tooltips</source>
         <translation>不要顯示檔案工具提示</translation>
@@ -607,9 +620,8 @@ are left clicked, even when it is not the default file manager.</source>
         <translation>桌布資料夾</translation>
     </message>
     <message>
-        <location filename="../desktop-preferences.ui" line="587"/>
         <source>Randomize the slide show</source>
-        <translation>隨機幻燈片播放</translation>
+        <translation type="vanished">隨機幻燈片播放</translation>
     </message>
     <message>
         <location filename="../desktop-preferences.ui" line="620"/>


### PR DESCRIPTION
Updated translations this time :)

Examining the diff I've noticed some translations for Arabic, Bulgarian and others where the change resulted in **unfinished translations** (also vanished translations which is concerning).

Is this acceptable, or should they be patched with previous translations?

I understand this is probably not a good time to open this PR...